### PR TITLE
Add indirect call scheduler, tests

### DIFF
--- a/Core/EvaluatorV2/CMakeLists.txt
+++ b/Core/EvaluatorV2/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(EvaluatorV2 BlockGenerator.cpp Instruction.cpp Lambda.cpp Program.cpp)
+add_library(EvaluatorV2 BlockGenerator.cpp Instruction.cpp Lambda.cpp Program.cpp CompileProgram.cpp)
 target_link_libraries(EvaluatorV2 FunGPUCore)
 
 add_subdirectory(tests)

--- a/Core/EvaluatorV2/CompileProgram.cpp
+++ b/Core/EvaluatorV2/CompileProgram.cpp
@@ -1,0 +1,37 @@
+#include "Core/EvaluatorV2/CompileProgram.hpp"
+#include "Core/Parser.hpp"
+#include "Core/Compiler.hpp"
+#include "Core/EvaluatorV2/BlockGenerator.h"
+#include "Core/BlockPrep.hpp"
+
+namespace FunGPU::EvaluatorV2 {
+  Program compile_program(const std::string& path, const Index_t registers_per_thread, const Index_t threads_per_block,
+  cl::sycl::buffer<PortableMemPool>& mem_pool_buffer) {
+    Parser parser(path);
+    auto parsed_result = parser.ParseProgram();
+    std::cout << "Parsed program: " << std::endl;
+    parsed_result->DebugPrint(0);
+    std::cout << std::endl;
+
+    BlockPrep block_prep(registers_per_thread, threads_per_block, threads_per_block, mem_pool_buffer);
+    BlockGenerator block_generator(mem_pool_buffer, registers_per_thread);
+
+    Compiler compiler(parsed_result, mem_pool_buffer);
+    auto compiled_result = compiler.Compile();
+    std::cout << "Compiled program: " << std::endl;
+    compiler.DebugPrintAST(compiled_result);
+    std::cout << std::endl;
+
+    compiled_result = block_prep.PrepareForBlockGeneration(compiled_result);
+    std::cout << "Program after prep for block generation: " << std::endl;
+    compiler.DebugPrintAST(compiled_result);
+    std::cout << std::endl << std::endl;
+
+    const auto program = block_generator.construct_blocks(compiled_result);
+    auto mem_pool_acc =
+        mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>();
+    std::cout << "Printed program: " << std::endl;
+    std::cout << print(program, mem_pool_acc);
+    return program;
+  }
+}

--- a/Core/EvaluatorV2/CompileProgram.hpp
+++ b/Core/EvaluatorV2/CompileProgram.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "Core/EvaluatorV2/Program.hpp"
+#include "Core/PortableMemPool.hpp"
+#include <string>
+
+namespace FunGPU::EvaluatorV2 {
+  Program compile_program(const std::string& path, Index_t registers_per_thread, Index_t threads_per_block,
+    cl::sycl::buffer<PortableMemPool>&);
+}

--- a/Core/EvaluatorV2/IndirectCallHandler.hpp
+++ b/Core/EvaluatorV2/IndirectCallHandler.hpp
@@ -1,0 +1,244 @@
+#pragma once
+
+#include "Core/PortableMemPool.hpp"
+#include "Core/EvaluatorV2/RuntimeValue.h"
+#include "Core/EvaluatorV2/Program.hpp"
+
+namespace FunGPU::EvaluatorV2 {
+  template<typename RuntimeBlockType, Index_t MaxNumIndirectCalls, Index_t MaxNumReactivations>
+  class IndirectCallHandler {
+    public:
+      using BlockExecGroupAccessor_t =
+        cl::sycl::accessor<typename RuntimeBlockType::BlockExecGroup, 1, cl::sycl::access::mode::read_write,
+                         cl::sycl::access::target::global_buffer>;
+
+      struct IndirectCallRequest {
+        IndirectCallRequest(const PortableMemPool::Handle<RuntimeBlockType> caller, const PortableMemPool::ArrayHandle<RuntimeValue> captures,
+          const Index_t calling_thread, const Index_t target_register, const PortableMemPool::ArrayHandle<RuntimeValue> args) :
+            caller(caller), captures(captures), calling_thread(calling_thread), target_register(target_register), args(args) {}
+
+        PortableMemPool::Handle<RuntimeBlockType> caller;
+        PortableMemPool::ArrayHandle<RuntimeValue> captures;
+        Index_t calling_thread;
+        Index_t target_register;
+        PortableMemPool::ArrayHandle<RuntimeValue> args;
+      };
+
+      class IndirectCallRequestBuffer {
+        public:
+        void append(const IndirectCallRequest&);
+
+        std::array<IndirectCallRequest, MaxNumIndirectCalls> indirect_call_requests;
+        Index_t num_indirect_call_reqs = 0;
+      };
+
+      class BlockReactivationRequestBuffer {
+        public:
+        void append(PortableMemPool::Handle<RuntimeBlockType>); 
+
+        std::array<typename RuntimeBlockType::BlockMetadata, MaxNumReactivations> runtime_blocks_reactivated;
+        Index_t num_runtime_blocks_reactivated = 0;
+      };
+
+      IndirectCallHandler(PortableMemPool::DeviceAccessor_t mem_pool_acc, const Index_t num_lambdas);
+      static typename RuntimeBlockType::BlockExecGroup create_block_exec_group(cl::sycl::queue&,
+        cl::sycl::buffer<PortableMemPool>&,
+        cl::sycl::buffer<IndirectCallHandler>&, 
+        Program);
+
+      void on_indirect_call(PortableMemPool::DeviceAccessor_t, PortableMemPool::Handle<RuntimeBlockType> caller, FunctionValue, Index_t thread, Index_t target_register, 
+        PortableMemPool::ArrayHandle<RuntimeValue> args);
+      void on_activate_block(PortableMemPool::Handle<RuntimeBlockType>);
+
+      typename RuntimeBlockType::BlockExecGroup setup_block_for_lambda(PortableMemPool::DeviceAccessor_t, Index_t lambda_idx, Program) const;
+      typename RuntimeBlockType::BlockExecGroup setup_block_for_reactivation(PortableMemPool::DeviceAccessor_t) const;
+
+      void setup_block(PortableMemPool::DeviceAccessor_t, BlockExecGroupAccessor_t, Index_t lambda_idx, Index_t thread_idx) const;
+
+      PortableMemPool::ArrayHandle<IndirectCallRequestBuffer> indirect_call_requests_by_block;
+      BlockReactivationRequestBuffer block_reactivation_requests_by_block;
+  };
+  
+  template<typename RuntimeBlockType, Index_t MaxNumIndirectCalls, Index_t MaxNumReactivations>
+  typename RuntimeBlockType::BlockExecGroup IndirectCallHandler<RuntimeBlockType, MaxNumIndirectCalls, MaxNumReactivations>::setup_block_for_lambda(PortableMemPool::DeviceAccessor_t mem_pool_acc, 
+    const Index_t lambda_idx, const Program program) const {
+    const auto& indirect_call_reqs = mem_pool_acc[0].derefHandle(indirect_call_requests_by_block)[lambda_idx];
+    const auto num_blocks_required = (indirect_call_reqs.num_indirect_call_reqs + RuntimeBlockType::NumThreadsPerBlock - 1) / RuntimeBlockType::NumThreadsPerBlock;
+    const auto block_meta_handle = mem_pool_acc[0].AllocArray<typename RuntimeBlockType::BlockMetadata>(num_blocks_required);
+    const auto instructions_data = mem_pool_acc[0].derefHandle(program)[lambda_idx];
+    auto* block_metadata = mem_pool_acc[0].derefHandle(block_meta_handle);
+    Index_t max_num_instructions = 0;
+    for (Index_t i = 0; i < num_blocks_required; ++i) {
+      const auto runtime_block_handle = mem_pool_acc[0].Alloc<RuntimeBlockType>(instructions_data.instructions);
+      block_metadata[lambda_idx] = BlockMetadata(runtime_block_handle, instructions_data.instructions);
+      max_num_instructions = std::max(max_num_instructions, instructions_data.instructions.GetCount());
+    }
+    return typename RuntimeBlockType::BlockExecGroup(block_meta_handle, max_num_instructions);
+  }
+
+  template<typename RuntimeBlockType, Index_t MaxNumIndirectCalls, Index_t MaxNumReactivations>
+  typename RuntimeBlockType::BlockExecGroup IndirectCallHandler<RuntimeBlockType, MaxNumIndirectCalls, MaxNumReactivations>::setup_block_for_reactivation(PortableMemPool::DeviceAccessor_t mem_pool_acc) const {
+    const auto block_meta_handle = mem_pool_acc[0].AllocArray<typename RuntimeBlockType::BlockMetadata>(block_reactivation_requests_by_block.num_runtime_blocks_reactivated);
+    Index_t max_num_instructions = 0;
+    auto* block_meta_data = mem_pool_acc[0].derefHandle(block_meta_handle);
+    for (Index_t i = 0; i < block_meta_handle.GetCount(); ++i) {
+      const auto& source_block = mem_pool_acc[0].derefHandle(block_reactivation_requests_by_block.runtime_blocks_reactivated);
+      block_meta_handle[i] = BlockMetadata(source_block.m_handle, source_block.instruction_ref);
+      max_num_instructions = std::max(max_num_instructions, source_block.instruction_ref.GetCount());
+    }
+    return typename RuntimeBlockType::BlockExecGroup(block_meta_handle, max_num_instructions);
+  }
+
+  template<typename RuntimeBlockType, Index_t MaxNumIndirectCalls, Index_t MaxNumReactivations>
+  void 
+  IndirectCallHandler<RuntimeBlockType, MaxNumIndirectCalls, MaxNumReactivations>::setup_block(PortableMemPool::DeviceAccessor_t mem_pool_acc, 
+    BlockExecGroupAccessor_t block_exec_acc, const Index_t lambda_idx, const Index_t thread_idx) const {
+    const auto& indirect_call_reqs = mem_pool_acc[0].derefHandle(indirect_call_requests_by_block)[lambda_idx];
+    if (thread_idx >= indirect_call_reqs.num_indirect_call_reqs) {
+      return;
+    }
+    const auto& indirect_call_req = indirect_call_reqs.indirect_call_requests[thread_idx];
+    const auto block_idx = thread_idx / RuntimeBlockType::NumThreadsPerBlock;
+    auto& target_block = mem_pool_acc[0].derefHandle(block_exec_acc[lambda_idx].block_descs)[block_idx];
+    // captures first, then args.
+    auto& register_set = target_block.registers[block_idx];
+    const auto* capture_data = mem_pool_acc[0].derefHandle(indirect_call_req.captures);
+    auto it = std::copy(capture_data, capture_data + indirect_call_req.captures.GetCount(), register_set.begin());
+    const auto* arg_data = mem_pool_acc[0].derefHandle(indirect_call_req.args);
+    std::copy(arg_data, arg_data + indirect_call_req.args.GetCount(), it);
+
+    auto& target_address_data = target_block.target_data[block_idx];
+    target_address_data.block = indirect_call_req.caller;
+    target_address_data.thread = indirect_call_req.calling_thread;
+    target_address_data.register_idx = indirect_call_req.target_register;
+  }
+
+  template<typename RuntimeBlockType, Index_t MaxNumIndirectCalls, Index_t MaxNumReactivations>
+  void IndirectCallHandler<RuntimeBlockType, MaxNumIndirectCalls, MaxNumReactivations>::IndirectCallRequestBuffer::append(const IndirectCallRequest& req) {
+    cl::sycl::atomic<Index_t> count(
+        (cl::sycl::multi_ptr<Index_t,
+                             cl::sycl::access::address_space::global_space>(
+            &num_indirect_call_reqs)));
+    const auto target_idx = count.fetch_add(1);
+    indirect_call_requests[target_idx] = req;
+  }
+
+  template<typename RuntimeBlockType, Index_t MaxNumIndirectCalls, Index_t MaxNumReactivations>
+  void IndirectCallHandler<RuntimeBlockType, MaxNumIndirectCalls, MaxNumReactivations>::BlockReactivationRequestBuffer::append(const PortableMemPool::Handle<RuntimeBlockType> block) {
+    cl::sycl::atomic<Index_t> count(
+        (cl::sycl::multi_ptr<Index_t,
+                             cl::sycl::access::address_space::global_space>(
+            &num_runtime_blocks_reactivated)));
+    const auto target_idx = count.fetch_add(1);
+    runtime_blocks_reactivated[target_idx] = block.block_metadata();
+  }
+
+  template<typename RuntimeBlockType, Index_t MaxNumIndirectCalls, Index_t MaxNumReactivations>
+  void IndirectCallHandler<RuntimeBlockType, MaxNumIndirectCalls, MaxNumReactivations>::on_indirect_call(
+    PortableMemPool::DeviceAccessor_t mem_pool_acc,
+    const PortableMemPool::Handle<RuntimeBlockType> caller, 
+    const FunctionValue funv, 
+    const Index_t thread, 
+    const Index_t target_register, 
+    const PortableMemPool::ArrayHandle<RuntimeValue> args) {
+    const auto target_block_idx = funv.block_idx;
+    const IndirectCallRequest ind_call_req(caller, funv.captures, thread, target_register, args);
+    auto& indirect_call_req_buffer_for_block = mem_pool_acc[0].derefHandle(indirect_call_requests_by_block)[target_block_idx];
+    indirect_call_req_buffer_for_block.append(ind_call_req);
+  }
+
+  template<typename RuntimeBlockType, Index_t MaxNumIndirectCalls, Index_t MaxNumReactivations>
+  void IndirectCallHandler<RuntimeBlockType, MaxNumIndirectCalls, MaxNumReactivations>::on_activate_block(const PortableMemPool::Handle<RuntimeBlockType> block) {
+    block_reactivation_requests_by_block.append(block); 
+  }
+
+  template<typename RuntimeBlockType, Index_t MaxNumIndirectCalls, Index_t MaxNumReactivations>
+  typename RuntimeBlockType::BlockExecGroup IndirectCallHandler<RuntimeBlockType, MaxNumIndirectCalls, MaxNumReactivations>::create_block_exec_group(
+    cl::sycl::queue& work_queue,
+    cl::sycl::buffer<PortableMemPool>& mem_pool_buffer,
+    cl::sycl::buffer<IndirectCallHandler>& indirect_call_handler, 
+    const Program program) {
+    // Allocate blocks
+    cl::sycl::buffer<typename RuntimeBlockType::BlockExecGroup> block_exec_group_per_lambda(cl::sycl::range<1>(program.GetCount() + 1));
+    cl::sycl::buffer<Index_t> max_num_threads_per_lambda(cl::sycl::range<1>(1));
+    cl::sycl::buffer<Index_t> total_num_blocks(cl::sycl::range<1>(1));
+
+    max_num_threads_per_lambda.get_access<cl::sycl::access::mode::discard_write>()[0] = 0;
+    total_num_blocks.get_access<cl::sycl::access::mode::discard_write>()[0] = 0;
+
+     work_queue.submit([&](cl::sycl::handler &cgh) {
+      auto mem_pool_write = mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>(cgh);
+      auto block_exec_group_per_lambda_acc = block_exec_group_per_lambda.get_access<cl::sycl::access::mode::discard_write>(cgh);
+      auto indirect_call_handler_acc = indirect_call_handler.get_access<cl::sycl::access::mode::read_write>(cgh);
+      auto atomic_max_threads_per_lambda = max_num_threads_per_lambda.get_access<cl::sycl::access::mode::atomic>(cgh);
+      auto total_num_blocks_acc = total_num_blocks.get_access<cl::sycl::access::mode::atomic>(cgh);
+      cgh.parallel_for<class BlockGroupsPerLambda>(cl::sycl::range<1>(program.GetCount() + 1), [mem_pool_write, block_exec_group_per_lambda_acc, indirect_call_handler_acc, 
+        program, atomic_max_threads_per_lambda, total_num_blocks_acc](cl::sycl::item<1> itm) {
+        const auto lambda_idx = itm.get_linear_id();
+        if (lambda_idx < program.GetCount()) {
+          block_exec_group_per_lambda_acc[lambda_idx] = indirect_call_handler_acc[0].setup_block_for_lambda(mem_pool_write, lambda_idx, program);
+        } else {
+          block_exec_group_per_lambda_acc[lambda_idx] = indirect_call_handler_acc[0].setup_block_for_reactivations(mem_pool_write);
+        }
+        cl::sycl::atomic<Index_t> max_num_threads_per_lambda(
+                  atomic_max_threads_per_lambda[0]);
+        const auto num_blocks_in_lambda = block_exec_group_per_lambda_acc[lambda_idx].block_descs.GetCount();
+        max_num_threads_per_lambda.fetch_max(num_blocks_in_lambda * RuntimeBlockType::NumThreadsPerBlock);
+        cl::sycl::atomic<Index_t> total_num_blocks_atomic(
+            total_num_blocks_acc[0]);
+        total_num_blocks_atomic.fetch_add(num_blocks_in_lambda);
+      });
+     });
+     // Fill indirect call request blocks
+     work_queue.submit([&](cl::sycl::handler &cgh) {
+        auto mem_pool_write = mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>(cgh);
+        auto block_exec_group_per_lambda_acc = block_exec_group_per_lambda.get_access<cl::sycl::access::mode::read_write>(cgh);
+        auto indirect_call_handler_acc = indirect_call_handler.get_access<cl::sycl::access::mode::read_write>(cgh);
+        cgh.parallel_for<class InitBlocksPerThread>(cl::sycl::range<2>(program.GetCount(), max_num_threads_per_lambda.get_access<cl::sycl::access::mode::read>()[0]), [mem_pool_write, block_exec_group_per_lambda_acc, indirect_call_handler_acc] (const cl::sycl::item<2> itm) {
+          indirect_call_handler_acc[0].setup_block(mem_pool_write, block_exec_group_per_lambda_acc, itm.get_id(0), itm.get_id(1));
+        });
+     });
+
+    cl::sycl::buffer<typename RuntimeBlockType::BlockExecGroup> result(cl::sycl::range<1>(1));
+    work_queue.submit([&](cl::sycl::handler& cgh) {
+      auto mem_pool_write = mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>(cgh);
+      auto total_num_blocks_acc = total_num_blocks.get_access<cl::sycl::access::mode::read>(cgh);
+      auto result_acc = result.get_access<cl::sycl::access::mode::discard_write>(cgh);
+      cgh.single_task<class InitResult>([mem_pool_write, total_num_blocks_acc, result_acc] {
+        const auto all_block_descs = mem_pool_write[0].template AllocArray<typename RuntimeBlockType::BlockMetadata>(total_num_blocks_acc[0]);
+        result_acc[0] = typename RuntimeBlockType::BlockExecGroup(all_block_descs, 0);
+      });
+    });
+
+      cl::sycl::buffer<Index_t> copy_begin_idx(cl::sycl::range<1>(1));
+      copy_begin_idx.get_access<cl::sycl::access::mode::discard_write>()[0] = 0;
+     // Merge block exec groups into one.
+     work_queue.submit([&](cl::sycl::handler &cgh) {
+       auto mem_pool_write = mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>(cgh);
+       auto result_acc = result.get_access<cl::sycl::access::mode::read_write>(cgh);
+       auto block_exec_group_per_lambda_acc = block_exec_group_per_lambda.get_access<cl::sycl::access::mode::read>(cgh);
+       auto copy_begin_atomic_acc = copy_begin_idx.get_access<cl::sycl::access::mode::atomic>(cgh);
+       cgh.parallel_for<class MergeIntoResult>(cl::sycl::range<2>(block_exec_group_per_lambda.get_size(), max_num_threads_per_lambda.get_access<cl::sycl::access::mode::read>()[0] / RuntimeBlockType::NumThreadsPerBlock), 
+        [mem_pool_write, result_acc, block_exec_group_per_lambda_acc, copy_begin_atomic_acc](cl::sycl::item<2> itm) {
+        auto* target_block_descs = mem_pool_write[0].derefHandle(result_acc[0].block_descs);
+        cl::sycl::atomic<Index_t> copy_begin_atomic(copy_begin_atomic_acc[0]);
+        const auto source_block_descs = block_exec_group_per_lambda_acc[itm.get_id(0)].block_descs;
+        const auto copy_begin = copy_begin_atomic.fetch_add(1);
+        const auto source_data = mem_pool_write[0].derefHandle(source_block_descs);
+        if (itm.get_id(1) < source_block_descs.GetCount()) {
+          target_block_descs[copy_begin] = source_data[itm.get_id(1)];
+        }
+        if (itm.get_id(1) == 0) {
+          cl::sycl::atomic<Index_t, cl::sycl::access::address_space::global_space>
+              max_num_instructions_atomic(
+                  (cl::sycl::multi_ptr<
+                      Index_t, cl::sycl::access::address_space::global_space>(
+                      &result_acc[0].max_num_instructions)));
+          max_num_instructions_atomic.fetch_max(block_exec_group_per_lambda_acc[itm.get_id(0)].max_num_instructions);
+        }
+       });
+     });
+
+     return result.template get_access<cl::sycl::access::mode::read>()[0];
+  }
+}

--- a/Core/EvaluatorV2/RuntimeBlock.hpp
+++ b/Core/EvaluatorV2/RuntimeBlock.hpp
@@ -12,6 +12,9 @@ template <Index_t RegistersPerThread, Index_t ThreadsPerBlock>
 class RuntimeBlock : public PortableMemPool::EnableHandleFromThis<
                          RuntimeBlock<RegistersPerThread, ThreadsPerBlock>> {
 public:
+  static constexpr Index_t NumRegistersPerThread = RegistersPerThread;
+  static constexpr Index_t NumThreadsPerBlock = ThreadsPerBlock;
+
   struct TargetAddress {
     PortableMemPool::Handle<RuntimeBlock> block;
     Index_t thread;
@@ -37,7 +40,7 @@ public:
     BlockExecGroup() = default;
 
     PortableMemPool::ArrayHandle<BlockMetadata> block_descs;
-    Index_t max_num_instructions;
+    Index_t max_num_instructions = 0;
   };
 
   enum class Status { READY, STALLED, COMPLETE };
@@ -45,6 +48,8 @@ public:
   using InstructionLocalMemAccessor =
       cl::sycl::accessor<Instruction, 2, cl::sycl::access::mode::read_write,
                          cl::sycl::access::target::local>;
+
+  explicit RuntimeBlock(const PortableMemPool::ArrayHandle<Instruction> instructions) : instruction_ref(instructions) {}
 
   template <typename OnIndirectCall, typename OnActivateBlock>
   Status evaluate(const Index_t block_idx, const Index_t thread,
@@ -66,9 +71,12 @@ public:
                        const RuntimeValue value,
                        OnActivateBlock &&on_activate_block);
 
+  BlockMetadata block_metadata() const { return BlockMetadata(m_handle, instruction_ref); }
+
   std::array<std::array<RuntimeValue, RegistersPerThread>, ThreadsPerBlock>
       registers;
   PortableMemPool::Handle<RuntimeBlock> m_handle;
+  PortableMemPool::ArrayHandle<Instruction> instruction_ref;
   TargetAddress target_data[ThreadsPerBlock];
   int num_outstanding_dependencies = 0;
 };
@@ -82,26 +90,26 @@ Index_t RuntimeBlock<RegistersPerThread, ThreadsPerBlock>::last_write_location(
       const DerivedInstruction
           &instr) requires HasTargetRegister<DerivedInstruction>{
       return instr.target_register;
-}
-, [](const auto &) {
-  // TODO error, should not happen
-  return Index_t(-1);
-}
-}; // namespace FunGPU::EvaluatorV2
+      }
+      , [](const auto &) {
+        // TODO error, should not happen
+        return Index_t(-1);
+      }
+    };
 
-const auto &register_set = registers[thread];
-const auto &instructions = all_instructions[block_idx];
-if (instruction_count < 3 ||
-    instructions[instruction_count - 3].type != InstructionType::IF) {
-  const auto prev_instruction = instructions[instruction_count - 1];
-  return visit(prev_instruction, extract_target_register, [](const auto &) {});
-}
-const auto &if_instr = instructions[instruction_count - 3].data.if_val;
-const auto last_instr =
-    static_cast<bool>(register_set[if_instr.predicate].data.float_val)
-        ? instructions[if_instr.goto_true]
-        : instructions[if_instr.goto_false];
-return visit(last_instr, extract_target_register, [](const auto &) {});
+    const auto &register_set = registers[thread];
+    const auto &instructions = all_instructions[block_idx];
+    if (instruction_count < 3 ||
+        instructions[instruction_count - 3].type != InstructionType::IF) {
+      const auto prev_instruction = instructions[instruction_count - 1];
+      return visit(prev_instruction, extract_target_register, [](const auto &) {});
+    }
+    const auto &if_instr = instructions[instruction_count - 3].data.if_val;
+    const auto last_instr =
+        static_cast<bool>(register_set[if_instr.predicate].data.float_val)
+            ? instructions[if_instr.goto_true]
+            : instructions[if_instr.goto_false];
+    return visit(last_instr, extract_target_register, [](const auto &) {});
 }
 
 template <Index_t RegistersPerThread, Index_t ThreadsPerBlock>

--- a/Core/EvaluatorV2/RuntimeValue.h
+++ b/Core/EvaluatorV2/RuntimeValue.h
@@ -20,9 +20,17 @@ struct FunctionValue {
 struct RuntimeValue {
   enum class Type { FLOAT, LAMBDA };
   union Data {
+    explicit Data(const Float_t float_val) : float_val(float_val) {}
+    explicit Data(const FunctionValue function_val) : function_val(function_val) {}
+    Data() = default;
+
     Float_t float_val;
     FunctionValue function_val;
   };
+
+  explicit RuntimeValue(const Float_t float_val) : type(Type::FLOAT), data(float_val) {}
+  explicit RuntimeValue(const FunctionValue function_val) : type(Type::LAMBDA), data(function_val) {}
+  RuntimeValue() = default;
 
   Type type;
   Data data;

--- a/Core/EvaluatorV2/tests/CMakeLists.txt
+++ b/Core/EvaluatorV2/tests/CMakeLists.txt
@@ -12,3 +12,13 @@ endif()
 target_compile_definitions(RuntimeBlockTestExe PRIVATE "BOOST_TEST_DYN_LINK=1")
 target_link_libraries(RuntimeBlockTestExe EvaluatorV2 ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 add_test(NAME RuntimeBlockTest WORKING_DIRECTORY ${CMAKE_BINARY_DIR} COMMAND RuntimeBlockTestExe)
+
+add_executable(IndirectCallHandlerTestExe IndirectCallHandler.cpp)
+if (ENABLE_COMPUTE_CPP)
+  add_sycl_to_target(
+          TARGET "IndirectCallHandlerTestExe"
+          SOURCES IndirectCallHandler.cpp)
+endif()
+target_compile_definitions(IndirectCallHandlerTestExe PRIVATE "BOOST_TEST_DYN_LINK=1")
+target_link_libraries(IndirectCallHandlerTestExe EvaluatorV2 ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+add_test(NAME IndirectCallHandlerTest WORKING_DIRECTORY ${CMAKE_BINARY_DIR} COMMAND IndirectCallHandlerTestExe)

--- a/Core/EvaluatorV2/tests/IndirectCallHandler.cpp
+++ b/Core/EvaluatorV2/tests/IndirectCallHandler.cpp
@@ -1,10 +1,12 @@
 #define BOOST_TEST_MODULE RuntimeBlockTestsModule
+#include "sycl/libkernel/item.hpp"
 #include "Core/EvaluatorV2/RuntimeValue.h"
 #include "Core/PortableMemPool.hpp"
 #include "sycl/handler.hpp"
 #include "Core/EvaluatorV2/IndirectCallHandler.hpp"
 #include "Core/EvaluatorV2/RuntimeBlock.hpp"
 #include "Core/EvaluatorV2/CompileProgram.hpp"
+#include <unordered_set>
 #include <boost/test/included/unit_test.hpp>
 
 namespace FunGPU::EvaluatorV2 {
@@ -36,7 +38,6 @@ namespace {
   };
 
   BOOST_FIXTURE_TEST_CASE(basic, BasicFixture) {
-    // simulate indirect call requested by instruction #2.
     cl::sycl::buffer<PortableMemPool::Handle<RuntimeBlockType>> caller_buf(cl::sycl::range<1>(1));
     work_queue.submit([&](cl::sycl::handler& cgh) {
       auto indirect_call_acc = indirect_call_handler_buff.get_access<cl::sycl::access::mode::read_write>(cgh);
@@ -47,7 +48,11 @@ namespace {
         const auto lambda_0 = mem_pool_acc[0].derefHandle(tmp_program)[0];
         const auto mock_caller = mem_pool_acc[0].Alloc<RuntimeBlockType>(lambda_0.instructions);
         caller_acc[0] = mock_caller;
-        FunctionValue function_value(0, PortableMemPool::ArrayHandle<RuntimeValue>());
+        const auto captures_acc = mem_pool_acc[0].AllocArray<RuntimeValue>(2);
+        auto* captures_data = mem_pool_acc[0].derefHandle(captures_acc);
+        captures_data[0] = RuntimeValue(2.f);
+        captures_data[1] = RuntimeValue(3.f);
+        FunctionValue function_value(0, captures_acc);
         const auto test_args = mem_pool_acc[0].AllocArray<RuntimeValue>(1);
         RuntimeValue& arg_val = mem_pool_acc[0].derefHandle(test_args)[0];
         arg_val.type = RuntimeValue::Type::FLOAT;
@@ -65,15 +70,148 @@ namespace {
     BOOST_REQUIRE(block_meta.instructions != PortableMemPool::ArrayHandle<Instruction>());
     BOOST_REQUIRE(block_meta.block != PortableMemPool::Handle<RuntimeBlockType>());
     const auto& first_block = *mem_pool_acc[0].derefHandle(block_meta.block);
-    RuntimeValue expected_value(RuntimeValue(42));
-    const auto actual_val = first_block.registers[0][0];
-    BOOST_CHECK_EQUAL(static_cast<int>(expected_value.type), static_cast<int>(actual_val.type));
-    BOOST_CHECK_EQUAL(expected_value.data.float_val, actual_val.data.float_val);
+    const std::array<RuntimeValue, 3> expected_captures_and_arg{RuntimeValue(2), RuntimeValue(3), RuntimeValue(42)};
+    for (Index_t i = 0; i < expected_captures_and_arg.size(); ++i) {
+      const auto actual_val = first_block.registers[0][i];
+      const auto expected_val = expected_captures_and_arg[i];
+      BOOST_CHECK_EQUAL(static_cast<int>(expected_val.type), static_cast<int>(actual_val.type));
+      BOOST_CHECK_EQUAL(expected_val.data.float_val, actual_val.data.float_val);
+    }
     BOOST_CHECK(block_meta.instructions == mem_pool_acc[0].derefHandle(program)[0].instructions);
     const auto& target_data = first_block.target_data[0];
     BOOST_CHECK_EQUAL(1, target_data.thread);
     BOOST_CHECK_EQUAL(2, target_data.register_idx);
     BOOST_CHECK(caller_buf.get_access<cl::sycl::access::mode::read>()[0] == target_data.block);
   }
+
+struct AdvancedFixture : public Fixture {
+  AdvancedFixture() : Fixture("./TestPrograms/ListExample.fgpu") {}
+};
+
+// This one exercises multiple blocks, grouping of indirect call requests by lambda and concurrent merging.
+BOOST_FIXTURE_TEST_CASE(advanced, AdvancedFixture) {
+  // test invocation of lambdas 7, 8 and 9. Incomplete block for 7, 2 blocks for 8, 3 and 1 thread for 9
+  PortableMemPool::Handle<RuntimeBlockType> caller;
+  {
+    auto mem_pool_acc = mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>();
+    caller = mem_pool_acc[0].Alloc<RuntimeBlockType>(mem_pool_acc[0].derefHandle(program)[0].instructions);
+  }
+    work_queue.submit([&](cl::sycl::handler& cgh) {
+      auto indirect_call_acc = indirect_call_handler_buff.get_access<cl::sycl::access::mode::read_write>(cgh);
+      auto mem_pool_acc = mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>(cgh);
+      const auto tmp_program = program;
+      cgh.parallel_for<class RequestIndirectCalls>(cl::sycl::range<2>(3, RuntimeBlockType::NumThreadsPerBlock * 4), 
+        [indirect_call_acc, mem_pool_acc, tmp_program, caller] (const cl::sycl::item<2> itm) {
+        switch (itm.get_id(0)) {
+          case 0:
+            if (itm.get_id(1) >= RuntimeBlockType::NumThreadsPerBlock / 2) {
+              return;
+            }
+            break;
+          case 1:
+            if (itm.get_id(1) >= RuntimeBlockType::NumThreadsPerBlock * 2) {
+              return;
+            }
+            break;
+          case 2:
+            if (itm.get_id(1) >= RuntimeBlockType::NumThreadsPerBlock * 3 + 1) {
+              return;
+            }
+            break;
+        }
+        const auto captures_acc = mem_pool_acc[0].AllocArray<RuntimeValue>(itm.get_id(0) + 1);
+        auto* captures_data = mem_pool_acc[0].derefHandle(captures_acc);
+        const auto test_args = mem_pool_acc[0].AllocArray<RuntimeValue>(itm.get_id(0) + 4);
+        auto* arg_vals = mem_pool_acc[0].derefHandle(test_args);
+        for (Index_t i = 0; i < captures_acc.GetCount(); ++i) {
+          captures_data[i] = RuntimeValue(itm.get_id(0) + i);
+        }
+        for (Index_t i = 0; i < test_args.GetCount(); ++i) {
+          arg_vals[i] = RuntimeValue(itm.get_id(0) + i + captures_acc.GetCount());
+        }
+        FunctionValue function_value(itm.get_id(0) + 7, captures_acc);
+        indirect_call_acc[0].on_indirect_call(mem_pool_acc, caller, function_value, itm.get_id(0), itm.get_id(1), test_args);
+      });
+    });
+
+    const auto exec_group = IndirectCallHandlerType::create_block_exec_group(work_queue, mem_pool_buffer, 
+      indirect_call_handler_buff, program);
+    BOOST_CHECK_EQUAL(7, exec_group.block_descs.GetCount());
+    BOOST_CHECK_EQUAL(7, exec_group.max_num_instructions);
+    auto mem_pool_acc = mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>();
+
+    const auto generate_set = [](const auto num_threads) {
+      std::unordered_set<Index_t> result;
+      for (Index_t idx = 0; idx < num_threads; ++idx) {
+        result.emplace(idx);
+      }
+      return result;
+    };
+
+    std::map<Index_t, Index_t> num_blocks_per_lambda_idx;
+    std::map<Index_t, std::unordered_set<Index_t>> expected_target_regs_per_lambda;
+    expected_target_regs_per_lambda[0] = generate_set(RuntimeBlockType::NumThreadsPerBlock / 2);
+    expected_target_regs_per_lambda[1] = generate_set(RuntimeBlockType::NumThreadsPerBlock * 2);
+    expected_target_regs_per_lambda[2] = generate_set(RuntimeBlockType::NumThreadsPerBlock * 3 + 1);
+    for (Index_t i = 0; i < exec_group.block_descs.GetCount(); ++i) {
+      const auto& block_meta = mem_pool_acc[0].derefHandle(exec_group.block_descs)[i];
+      BOOST_REQUIRE(block_meta.instructions != PortableMemPool::ArrayHandle<Instruction>());
+      BOOST_REQUIRE(block_meta.block != PortableMemPool::Handle<RuntimeBlockType>());
+      const auto* lambdas = mem_pool_acc[0].derefHandle(program);
+      auto lambda_idx = 0;
+      if (block_meta.instructions == lambdas[7].instructions) {
+        lambda_idx = 0;
+      } else if (block_meta.instructions == lambdas[8].instructions) {
+        lambda_idx = 1;
+      } else if (block_meta.instructions == lambdas[9].instructions) {
+        lambda_idx = 2;
+      } else {
+        BOOST_FAIL("Instructions not for one of expected lambdas");
+      }
+      num_blocks_per_lambda_idx[lambda_idx]++;
+      BOOST_CHECK(block_meta.instructions == mem_pool_acc[0].derefHandle(program)[lambda_idx + 7].instructions);
+      const auto& first_block = *mem_pool_acc[0].derefHandle(block_meta.block);
+      std::vector<RuntimeValue> expected_captures_and_args;
+      for (Index_t j = 0; j < (lambda_idx + 4) + (lambda_idx + 1); j++) {
+        expected_captures_and_args.emplace_back(j + lambda_idx);
+      }
+      const auto num_threads = [&] {
+        switch (lambda_idx) {
+          case 0:
+            return RuntimeBlockType::NumThreadsPerBlock / 2;
+          case 1:
+            return RuntimeBlockType::NumThreadsPerBlock;
+          case 2:
+            return num_blocks_per_lambda_idx[2] <= 3 ?  RuntimeBlockType::NumThreadsPerBlock : 1;
+        }
+        BOOST_FAIL("Unexpected");
+        return Index_t(0);
+      }();
+      auto& expected_thread_indices = expected_target_regs_per_lambda[lambda_idx];
+      for (Index_t tid = 0; tid < num_threads; ++tid) {
+        for (Index_t j = 0; j < expected_captures_and_args.size(); ++j) {
+          const auto actual_val = first_block.registers[tid][j];
+          const auto expected_val = expected_captures_and_args[j];
+          BOOST_CHECK_EQUAL(static_cast<int>(expected_val.type), static_cast<int>(actual_val.type));
+          BOOST_CHECK_EQUAL(expected_val.data.float_val, actual_val.data.float_val);
+        }
+        const auto& target_data = first_block.target_data[tid];
+        BOOST_CHECK_EQUAL(lambda_idx, target_data.thread);
+        BOOST_CHECK_EQUAL(1, expected_thread_indices.erase(target_data.register_idx));
+        BOOST_CHECK(caller == target_data.block);
+      }
+    }
+    BOOST_CHECK_EQUAL(1, num_blocks_per_lambda_idx[0]);
+    BOOST_CHECK_EQUAL(2, num_blocks_per_lambda_idx[1]);
+    BOOST_CHECK_EQUAL(4, num_blocks_per_lambda_idx[2]);
+    for (const auto& [k, remaining_target_regs] : expected_target_regs_per_lambda) {
+      std::stringstream remaining_values;
+      for (const auto target_reg : remaining_target_regs) {
+        remaining_values << target_reg << ", ";
+      }
+      BOOST_TEST_INFO("lambda " << k << ", remaining values: " << remaining_values.str());
+      BOOST_CHECK(remaining_target_regs.empty());
+    }
+}
 }
 }

--- a/Core/EvaluatorV2/tests/IndirectCallHandler.cpp
+++ b/Core/EvaluatorV2/tests/IndirectCallHandler.cpp
@@ -1,11 +1,79 @@
 #define BOOST_TEST_MODULE RuntimeBlockTestsModule
+#include "Core/EvaluatorV2/RuntimeValue.h"
+#include "Core/PortableMemPool.hpp"
+#include "sycl/handler.hpp"
 #include "Core/EvaluatorV2/IndirectCallHandler.hpp"
+#include "Core/EvaluatorV2/RuntimeBlock.hpp"
+#include "Core/EvaluatorV2/CompileProgram.hpp"
 #include <boost/test/included/unit_test.hpp>
 
 namespace FunGPU::EvaluatorV2 {
 namespace {
-  BOOST_AUTO_TEST_CASE(basic) {
+  struct Fixture {
+    using RuntimeBlockType = RuntimeBlock<64, 32>;
+    using IndirectCallHandlerType = IndirectCallHandler<RuntimeBlockType, 128, 128>;
     
+    Fixture(const std::string& program_path) : program(compile_program(program_path, RuntimeBlockType::NumThreadsPerBlock, RuntimeBlockType::NumThreadsPerBlock, mem_pool_buffer))  {
+      std::cout
+        << "Running on "
+        << work_queue.get_device().get_info<cl::sycl::info::device::name>()
+        << ", block size: " << sizeof(RuntimeBlockType) << std::endl;
+    }
+
+    std::shared_ptr<PortableMemPool> mem_pool_data =
+      std::make_shared<PortableMemPool>();
+    cl::sycl::buffer<PortableMemPool> mem_pool_buffer{mem_pool_data,
+                                                      cl::sycl::range<1>(1)};
+    const Program program;
+    std::shared_ptr<IndirectCallHandlerType> indirect_call_handler = std::make_shared<IndirectCallHandlerType>(mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>(), 
+      program.GetCount());
+    cl::sycl::buffer<IndirectCallHandlerType> indirect_call_handler_buff{indirect_call_handler, cl::sycl::range<1>(1)};
+    cl::sycl::queue work_queue;
+  };
+
+  struct BasicFixture : public Fixture {
+    BasicFixture() : Fixture("./TestPrograms/SimpleCall.fgpu") {}
+  };
+
+  BOOST_FIXTURE_TEST_CASE(basic, BasicFixture) {
+    // simulate indirect call requested by instruction #2.
+    cl::sycl::buffer<PortableMemPool::Handle<RuntimeBlockType>> caller_buf(cl::sycl::range<1>(1));
+    work_queue.submit([&](cl::sycl::handler& cgh) {
+      auto indirect_call_acc = indirect_call_handler_buff.get_access<cl::sycl::access::mode::read_write>(cgh);
+      auto mem_pool_acc = mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>(cgh);
+      auto caller_acc = caller_buf.get_access<cl::sycl::access::mode::discard_write>(cgh);
+      const auto tmp_program = program;
+      cgh.single_task<class RequestIndirectCall>([indirect_call_acc, mem_pool_acc, tmp_program, caller_acc] {
+        const auto lambda_0 = mem_pool_acc[0].derefHandle(tmp_program)[0];
+        const auto mock_caller = mem_pool_acc[0].Alloc<RuntimeBlockType>(lambda_0.instructions);
+        caller_acc[0] = mock_caller;
+        FunctionValue function_value(0, PortableMemPool::ArrayHandle<RuntimeValue>());
+        const auto test_args = mem_pool_acc[0].AllocArray<RuntimeValue>(1);
+        RuntimeValue& arg_val = mem_pool_acc[0].derefHandle(test_args)[0];
+        arg_val.type = RuntimeValue::Type::FLOAT;
+        arg_val.data.float_val = 42;
+        indirect_call_acc[0].on_indirect_call(mem_pool_acc, mock_caller, function_value, 1, 2, test_args);
+      });
+    });
+
+    const auto exec_group = IndirectCallHandlerType::create_block_exec_group(work_queue, mem_pool_buffer, 
+      indirect_call_handler_buff, program);
+    BOOST_CHECK_EQUAL(1, exec_group.block_descs.GetCount());
+    BOOST_CHECK_EQUAL(3, exec_group.max_num_instructions);
+    auto mem_pool_acc = mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>();
+    const auto& block_meta = mem_pool_acc[0].derefHandle(exec_group.block_descs)[0];
+    BOOST_REQUIRE(block_meta.instructions != PortableMemPool::ArrayHandle<Instruction>());
+    BOOST_REQUIRE(block_meta.block != PortableMemPool::Handle<RuntimeBlockType>());
+    const auto& first_block = *mem_pool_acc[0].derefHandle(block_meta.block);
+    RuntimeValue expected_value(RuntimeValue(42));
+    const auto actual_val = first_block.registers[0][0];
+    BOOST_CHECK_EQUAL(static_cast<int>(expected_value.type), static_cast<int>(actual_val.type));
+    BOOST_CHECK_EQUAL(expected_value.data.float_val, actual_val.data.float_val);
+    BOOST_CHECK(block_meta.instructions == mem_pool_acc[0].derefHandle(program)[0].instructions);
+    const auto& target_data = first_block.target_data[0];
+    BOOST_CHECK_EQUAL(1, target_data.thread);
+    BOOST_CHECK_EQUAL(2, target_data.register_idx);
+    BOOST_CHECK(caller_buf.get_access<cl::sycl::access::mode::read>()[0] == target_data.block);
   }
 }
 }

--- a/Core/EvaluatorV2/tests/IndirectCallHandler.cpp
+++ b/Core/EvaluatorV2/tests/IndirectCallHandler.cpp
@@ -1,0 +1,11 @@
+#define BOOST_TEST_MODULE RuntimeBlockTestsModule
+#include "Core/EvaluatorV2/IndirectCallHandler.hpp"
+#include <boost/test/included/unit_test.hpp>
+
+namespace FunGPU::EvaluatorV2 {
+namespace {
+  BOOST_AUTO_TEST_CASE(basic) {
+    
+  }
+}
+}

--- a/Core/EvaluatorV2/tests/RuntimeBlock.cpp
+++ b/Core/EvaluatorV2/tests/RuntimeBlock.cpp
@@ -129,7 +129,7 @@ struct Fixture {
       auto mem_pool_acc =
           mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>();
       const auto *lambdas = mem_pool_acc[0].derefHandle(no_bindings_program);
-      const auto block_handle = mem_pool_acc[0].Alloc<RuntimeBlockType>();
+      const auto block_handle = mem_pool_acc[0].Alloc<RuntimeBlockType>(lambdas[0].instructions);
       const auto block_metadata_array =
           mem_pool_acc[0].AllocArray<RuntimeBlockType::BlockMetadata>(1);
       auto *block_meta_array_data =
@@ -160,7 +160,7 @@ struct Fixture {
         const auto no_bindings_program = generate_program(prog);
         BOOST_REQUIRE_EQUAL(1, no_bindings_program.GetCount());
         const auto *lambdas = mem_pool_acc[0].derefHandle(no_bindings_program);
-        const auto block_handle = mem_pool_acc[0].Alloc<RuntimeBlockType>();
+        const auto block_handle = mem_pool_acc[0].Alloc<RuntimeBlockType>(lambdas[0].instructions);
         BOOST_REQUIRE(block_handle !=
                       PortableMemPool::Handle<RuntimeBlockType>());
         block_metadata_array_data[i++] = RuntimeBlockType::BlockMetadata(

--- a/Core/EvaluatorV2/tests/RuntimeBlock.cpp
+++ b/Core/EvaluatorV2/tests/RuntimeBlock.cpp
@@ -5,6 +5,7 @@
 #include "Core/EvaluatorV2/BlockGenerator.h"
 #include "Core/Parser.hpp"
 #include "Core/Visitor.hpp"
+#include "Core/EvaluatorV2/CompileProgram.hpp"
 #include <boost/test/included/unit_test.hpp>
 #include <boost/test/tools/old/interface.hpp>
 #include <cmath>
@@ -27,29 +28,7 @@ struct Fixture {
   }
 
   Program generate_program(const std::string &program_path) {
-    Parser parser(program_path);
-    auto parsed_result = parser.ParseProgram();
-    std::cout << "Parsed program: " << std::endl;
-    parsed_result->DebugPrint(0);
-    std::cout << std::endl;
-
-    Compiler compiler(parsed_result, mem_pool_buffer);
-    auto compiled_result = compiler.Compile();
-    std::cout << "Compiled program: " << std::endl;
-    compiler.DebugPrintAST(compiled_result);
-    std::cout << std::endl;
-
-    compiled_result = block_prep.PrepareForBlockGeneration(compiled_result);
-    std::cout << "Program after prep for block generation: " << std::endl;
-    compiler.DebugPrintAST(compiled_result);
-    std::cout << std::endl << std::endl;
-
-    const auto program = block_generator.construct_blocks(compiled_result);
-    auto mem_pool_acc =
-        mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>();
-    std::cout << "Printed program: " << std::endl;
-    std::cout << print(program, mem_pool_acc);
-    return program;
+    return compile_program(program_path, REGISTERS_PER_THREAD, THREADS_PER_BLOCK, mem_pool_buffer);
   }
 
   void check_block_evaluates_to_value(


### PR DESCRIPTION
Add a class handling collection of indirect call and block reactivation requests. Attach logic for grouping requests for the same lambda into blocks to the same class. Unit test.