### PR TITLE
Evaluator V2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4.3)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2a -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2a")
 
 include_directories(${CMAKE_SOURCE_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4.3)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2a")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2a -g")
 
 include_directories(${CMAKE_SOURCE_DIR})
 

--- a/Core/CPUEvaluator.cpp
+++ b/Core/CPUEvaluator.cpp
@@ -375,7 +375,11 @@ CPUEvaluator::EvaluateProgram(const Compiler::ASTNodeHandle &rootNode,
     std::cerr << "Sycl exception: " << e.what() << std::endl;
   }
   const auto end_time = std::chrono::high_resolution_clock::now();
-  std::cout << "total time: " << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - begin_time).count() << std::endl;
+  std::cout << "total time: "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(end_time -
+                                                                     begin_time)
+                   .count()
+            << std::endl;
   m_workQueue.submit([&](handler &cgh) {
     auto memPoolAcc = m_memPoolBuff.get_access<access::mode::read_write>(cgh);
     auto resultOnHostAcc =

--- a/Core/CPUEvaluator.cpp
+++ b/Core/CPUEvaluator.cpp
@@ -275,6 +275,7 @@ void CPUEvaluator::PerformGarbageCollection(const Index_t numActiveBlocks) {
 CPUEvaluator::RuntimeBlock_t::RuntimeValue
 CPUEvaluator::EvaluateProgram(const Compiler::ASTNodeHandle &rootNode,
                               Index_t &maxConcurrentBlocksDuringExec) {
+  const auto begin_time = std::chrono::high_resolution_clock::now();
   CreateFirstBlock(rootNode);
 
   maxConcurrentBlocksDuringExec = 0;
@@ -282,7 +283,9 @@ CPUEvaluator::EvaluateProgram(const Compiler::ASTNodeHandle &rootNode,
   m_requiresGarbageCollection.get_access<access::mode::discard_write>()[0] =
       false;
   try {
+    Index_t num_steps = 0;
     while (true) {
+      ++num_steps;
       m_workQueue.submit([&](handler &cgh) {
         auto numActiveBlocksWrite =
             m_numActiveBlocksBuff.get_access<access::mode::discard_write>(cgh);
@@ -367,10 +370,12 @@ CPUEvaluator::EvaluateProgram(const Compiler::ASTNodeHandle &rootNode,
             });
       });
     }
+    std::cout << "Num steps: " << num_steps << std::endl;
   } catch (cl::sycl::exception e) {
     std::cerr << "Sycl exception: " << e.what() << std::endl;
   }
-
+  const auto end_time = std::chrono::high_resolution_clock::now();
+  std::cout << "total time: " << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - begin_time).count() << std::endl;
   m_workQueue.submit([&](handler &cgh) {
     auto memPoolAcc = m_memPoolBuff.get_access<access::mode::read_write>(cgh);
     auto resultOnHostAcc =

--- a/Core/EvaluatorV2/BlockGenerator.cpp
+++ b/Core/EvaluatorV2/BlockGenerator.cpp
@@ -170,7 +170,8 @@ Lambda BlockGenerator::construct_block(
 
   std::unordered_map<Index_t, Index_t> lambda_space_ident_to_register;
   std::set<Index_t> lambda_captured_indices;
-  if (const auto block_iter = lambdas_to_blocks.find(lambda); block_iter != lambdas_to_blocks.end() && block_iter->second == 2) {
+  if (const auto block_iter = lambdas_to_blocks.find(lambda);
+      block_iter != lambdas_to_blocks.end() && block_iter->second == 2) {
     volatile int x = 1;
     x = x + 1;
   }
@@ -251,7 +252,9 @@ Lambda BlockGenerator::construct_block(
             *mem_pool_acc[0].derefHandle(ast_node),
             Visitor{
                 [&](const Compiler::CallNode &call_node) {
-                  result.type = is_tail_instruction ? InstructionType::BLOCKING_CALL_INDIRECT : InstructionType::CALL_INDIRECT;
+                  result.type = is_tail_instruction
+                                    ? InstructionType::BLOCKING_CALL_INDIRECT
+                                    : InstructionType::CALL_INDIRECT;
                   const auto &target_ast_node =
                       *mem_pool_acc[0].derefHandle(call_node.m_target);
                   result.data.call_indirect.lambda_idx =
@@ -269,23 +272,26 @@ Lambda BlockGenerator::construct_block(
                     arg_indices_data[arg_idx] =
                         lookup_register_for_ident(arg_elem);
                   }
-                  const auto assign_call_indirect_fields = [&](CallIndirectCommon& derived_result) {
-                    derived_result.arg_indices = arg_indices;
-                    derived_result.target_register =
-                        allocate_register_or_use_pre_allocated();
-                  };
-                  visit(result, Visitor {
-                    [&](CallIndirect& call_indirect) {
-                      assign_call_indirect_fields(call_indirect);
-                    },
-                    [&](BlockingCallIndirect& blocking_indirect) {
-                      assign_call_indirect_fields(blocking_indirect);
-                    }, [](auto&) {
-                      throw std::invalid_argument("Unexpected");
-                    }
-                  }, [](auto&) {
-                    throw std::invalid_argument("Unexpected");
-                  });
+                  const auto assign_call_indirect_fields =
+                      [&](CallIndirectCommon &derived_result) {
+                        derived_result.arg_indices = arg_indices;
+                        derived_result.target_register =
+                            allocate_register_or_use_pre_allocated();
+                      };
+                  visit(result,
+                        Visitor{[&](CallIndirect &call_indirect) {
+                                  assign_call_indirect_fields(call_indirect);
+                                },
+                                [&](BlockingCallIndirect &blocking_indirect) {
+                                  assign_call_indirect_fields(
+                                      blocking_indirect);
+                                },
+                                [](auto &) {
+                                  throw std::invalid_argument("Unexpected");
+                                }},
+                        [](auto &) {
+                          throw std::invalid_argument("Unexpected");
+                        });
                 },
                 [&](const Compiler::LambdaNode &) {
                   result.type = InstructionType::CREATE_LAMBDA;
@@ -556,18 +562,19 @@ Lambda BlockGenerator::construct_block(
       const auto &if_node = static_cast<const Compiler::IfNode &>(*child_expr);
       result_instructions.emplace_back(primitive_expression_to_instruction(
           pending_generation, std::nullopt, false));
-      result_instructions.emplace_back(
-          primitive_expression_to_instruction(if_node.m_then, std::nullopt, true));
-      result_instructions.emplace_back(
-          primitive_expression_to_instruction(if_node.m_else, std::nullopt, true));
+      result_instructions.emplace_back(primitive_expression_to_instruction(
+          if_node.m_then, std::nullopt, true));
+      result_instructions.emplace_back(primitive_expression_to_instruction(
+          if_node.m_else, std::nullopt, true));
       // If exprs are always in tail position
       pending_generation = Compiler::ASTNodeHandle();
       break;
     }
     default:
       // Tail instruction
-      auto& tail_instruction = result_instructions.emplace_back(primitive_expression_to_instruction(
-          pending_generation, std::nullopt, true));
+      auto &tail_instruction =
+          result_instructions.emplace_back(primitive_expression_to_instruction(
+              pending_generation, std::nullopt, true));
       pending_generation = Compiler::ASTNodeHandle();
       break;
     }

--- a/Core/EvaluatorV2/BlockGenerator.cpp
+++ b/Core/EvaluatorV2/BlockGenerator.cpp
@@ -170,11 +170,6 @@ Lambda BlockGenerator::construct_block(
 
   std::unordered_map<Index_t, Index_t> lambda_space_ident_to_register;
   std::set<Index_t> lambda_captured_indices;
-  if (const auto block_iter = lambdas_to_blocks.find(lambda);
-      block_iter != lambdas_to_blocks.end() && block_iter->second == 2) {
-    volatile int x = 1;
-    x = x + 1;
-  }
   extract_lambda_space_captured_indices(lambda, 0, mem_pool_acc,
                                         lambda_captured_indices);
   std::unordered_map<Index_t, Index_t> lambda_space_ident_to_remaining_count;
@@ -304,10 +299,6 @@ Lambda BlockGenerator::construct_block(
                   }
                   result.data.create_lambda.block_idx =
                       lambda_to_block_idx_iter->second;
-                  if (lambda_to_block_idx_iter->second == 2) {
-                    volatile int x = 1;
-                    x = x + 1;
-                  }
                   const auto captured_indices = [&] {
                     std::set<Index_t> captured_indices_set;
                     extract_lambda_space_captured_indices(

--- a/Core/EvaluatorV2/BlockGenerator.cpp
+++ b/Core/EvaluatorV2/BlockGenerator.cpp
@@ -170,6 +170,10 @@ Lambda BlockGenerator::construct_block(
 
   std::unordered_map<Index_t, Index_t> lambda_space_ident_to_register;
   std::set<Index_t> lambda_captured_indices;
+  if (const auto block_iter = lambdas_to_blocks.find(lambda); block_iter != lambdas_to_blocks.end() && block_iter->second == 2) {
+    volatile int x = 1;
+    x = x + 1;
+  }
   extract_lambda_space_captured_indices(lambda, 0, mem_pool_acc,
                                         lambda_captured_indices);
   std::unordered_map<Index_t, Index_t> lambda_space_ident_to_remaining_count;
@@ -182,9 +186,8 @@ Lambda BlockGenerator::construct_block(
     }
   }
   for (Index_t i = 0; i < lambda_node.m_argCount; ++i) {
-    const auto lambda_space_ident = lambda_node.m_argCount - i - 1;
-    lambda_space_ident_to_remaining_count[lambda_space_ident] = 0;
-    lambda_space_ident_to_register[lambda_space_ident] = free_indices.front();
+    lambda_space_ident_to_remaining_count[i] = 0;
+    lambda_space_ident_to_register[i] = free_indices.front();
     free_indices.pop_front();
   }
 
@@ -235,7 +238,8 @@ Lambda BlockGenerator::construct_block(
   std::vector<Instruction> result_instructions;
   const auto primitive_expression_to_instruction =
       [&](const Compiler::ASTNodeHandle ast_node,
-          const std::optional<Index_t> pre_allocated_register) {
+          const std::optional<Index_t> pre_allocated_register,
+          bool is_tail_instruction) {
         Instruction result;
         const auto allocate_register_or_use_pre_allocated = [&] {
           if (pre_allocated_register.has_value()) {
@@ -247,7 +251,7 @@ Lambda BlockGenerator::construct_block(
             *mem_pool_acc[0].derefHandle(ast_node),
             Visitor{
                 [&](const Compiler::CallNode &call_node) {
-                  result.type = InstructionType::CALL_INDIRECT;
+                  result.type = is_tail_instruction ? InstructionType::BLOCKING_CALL_INDIRECT : InstructionType::CALL_INDIRECT;
                   const auto &target_ast_node =
                       *mem_pool_acc[0].derefHandle(call_node.m_target);
                   result.data.call_indirect.lambda_idx =
@@ -265,9 +269,23 @@ Lambda BlockGenerator::construct_block(
                     arg_indices_data[arg_idx] =
                         lookup_register_for_ident(arg_elem);
                   }
-                  result.data.call_indirect.arg_indices = arg_indices;
-                  result.data.call_indirect.target_register =
-                      allocate_register_or_use_pre_allocated();
+                  const auto assign_call_indirect_fields = [&](CallIndirectCommon& derived_result) {
+                    derived_result.arg_indices = arg_indices;
+                    derived_result.target_register =
+                        allocate_register_or_use_pre_allocated();
+                  };
+                  visit(result, Visitor {
+                    [&](CallIndirect& call_indirect) {
+                      assign_call_indirect_fields(call_indirect);
+                    },
+                    [&](BlockingCallIndirect& blocking_indirect) {
+                      assign_call_indirect_fields(blocking_indirect);
+                    }, [](auto&) {
+                      throw std::invalid_argument("Unexpected");
+                    }
+                  }, [](auto&) {
+                    throw std::invalid_argument("Unexpected");
+                  });
                 },
                 [&](const Compiler::LambdaNode &) {
                   result.type = InstructionType::CREATE_LAMBDA;
@@ -280,6 +298,10 @@ Lambda BlockGenerator::construct_block(
                   }
                   result.data.create_lambda.block_idx =
                       lambda_to_block_idx_iter->second;
+                  if (lambda_to_block_idx_iter->second == 2) {
+                    volatile int x = 1;
+                    x = x + 1;
+                  }
                   const auto captured_indices = [&] {
                     std::set<Index_t> captured_indices_set;
                     extract_lambda_space_captured_indices(
@@ -515,7 +537,7 @@ Lambda BlockGenerator::construct_block(
         }
         const auto &instruction = result_instructions.emplace_back(
             primitive_expression_to_instruction(bound_expr_data[i],
-                                                pre_allocated_register));
+                                                pre_allocated_register, false));
         bindingRequiresIndirectCall =
             bindingRequiresIndirectCall ||
             instruction.type == InstructionType::CALL_INDIRECT;
@@ -533,19 +555,19 @@ Lambda BlockGenerator::construct_block(
     case Compiler::ASTNode::Type::If: {
       const auto &if_node = static_cast<const Compiler::IfNode &>(*child_expr);
       result_instructions.emplace_back(primitive_expression_to_instruction(
-          pending_generation, std::nullopt));
+          pending_generation, std::nullopt, false));
       result_instructions.emplace_back(
-          primitive_expression_to_instruction(if_node.m_then, std::nullopt));
+          primitive_expression_to_instruction(if_node.m_then, std::nullopt, true));
       result_instructions.emplace_back(
-          primitive_expression_to_instruction(if_node.m_else, std::nullopt));
+          primitive_expression_to_instruction(if_node.m_else, std::nullopt, true));
       // If exprs are always in tail position
       pending_generation = Compiler::ASTNodeHandle();
       break;
     }
     default:
       // Tail instruction
-      result_instructions.emplace_back(primitive_expression_to_instruction(
-          pending_generation, std::nullopt));
+      auto& tail_instruction = result_instructions.emplace_back(primitive_expression_to_instruction(
+          pending_generation, std::nullopt, true));
       pending_generation = Compiler::ASTNodeHandle();
       break;
     }

--- a/Core/EvaluatorV2/CMakeLists.txt
+++ b/Core/EvaluatorV2/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(EvaluatorV2 BlockGenerator.cpp Instruction.cpp Lambda.cpp Program.cpp CompileProgram.cpp)
+add_library(EvaluatorV2 BlockGenerator.cpp Instruction.cpp Lambda.cpp Program.cpp CompileProgram.cpp Evaluator.cpp)
 target_link_libraries(EvaluatorV2 FunGPUCore)
 
 add_subdirectory(tests)

--- a/Core/EvaluatorV2/CMakeLists.txt
+++ b/Core/EvaluatorV2/CMakeLists.txt
@@ -1,4 +1,12 @@
 add_library(EvaluatorV2 BlockGenerator.cpp Instruction.cpp Lambda.cpp Program.cpp CompileProgram.cpp Evaluator.cpp)
 target_link_libraries(EvaluatorV2 FunGPUCore)
 
+add_executable(FunGPUV2 FunGPUV2.cpp)
+if (ENABLE_COMPUTE_CPP)
+  add_sycl_to_target(
+          TARGET "FunGPUV2"
+          SOURCES FunGPUV2.cpp)
+endif()
+target_link_libraries(FunGPUV2 EvaluatorV2 ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+
 add_subdirectory(tests)

--- a/Core/EvaluatorV2/Evaluator.cpp
+++ b/Core/EvaluatorV2/Evaluator.cpp
@@ -46,7 +46,11 @@ RuntimeValue Evaluator::compute(const Program program) {
   }
   const auto end_time = std::chrono::high_resolution_clock::now();
   std::cout << "num_steps: " << num_steps << std::endl;
-  std::cout << "total time: " << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - begin_time).count() << std::endl;
+  std::cout << "total time: "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(end_time -
+                                                                     begin_time)
+                   .count()
+            << std::endl;
   return read_result(first_block_);
 }
 
@@ -95,8 +99,9 @@ auto Evaluator::schedule_next_batch(const Program program)
       work_queue_, mem_pool_buffer_, indirect_call_handler_buffer_, program);
   if (next_batch.block_descs.GetCount() > 1) {
     /*std::cout << "Multiple blocks returned" << std::endl;
-    auto mem_pool_acc = mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>();
-    const auto* block_metadata = mem_pool_acc[0].derefHandle(next_batch.block_descs);
+    auto mem_pool_acc =
+    mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(); const
+    auto* block_metadata = mem_pool_acc[0].derefHandle(next_batch.block_descs);
     for (Index_t i = 0; i < next_batch.block_descs.GetCount(); ++i) {
       Index_t lambda_idx = std::numeric_limits<Index_t>::max();
       const auto* program_data = mem_pool_acc[0].derefHandle(program);
@@ -106,7 +111,8 @@ auto Evaluator::schedule_next_batch(const Program program)
           break;
         }
       }
-      std::cout << " block: num threads " << block_metadata[i].num_threads << " for lambda " << lambda_idx << std::endl;
+      std::cout << " block: num threads " << block_metadata[i].num_threads << "
+    for lambda " << lambda_idx << std::endl;
     }*/
     return next_batch;
   }

--- a/Core/EvaluatorV2/Evaluator.cpp
+++ b/Core/EvaluatorV2/Evaluator.cpp
@@ -35,10 +35,12 @@ RuntimeValue Evaluator::compute(const Program program) {
   });
 
   while (true) {
+    std::cout << "Scheduling next batch" << std::endl;
     const auto maybe_next_batch = schedule_next_batch(program);
     if (!maybe_next_batch.has_value()) {
       break;
     }
+    std::cout << "Running eval step" << std::endl;
     run_eval_step(*maybe_next_batch);
   }
 
@@ -89,6 +91,20 @@ auto Evaluator::schedule_next_batch(const Program program)
   const auto next_batch = IndirectCallHandlerType::create_block_exec_group(
       work_queue_, mem_pool_buffer_, indirect_call_handler_buffer_, program);
   if (next_batch.block_descs.GetCount() > 1) {
+    /*std::cout << "Multiple blocks returned" << std::endl;
+    auto mem_pool_acc = mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>();
+    const auto* block_metadata = mem_pool_acc[0].derefHandle(next_batch.block_descs);
+    for (Index_t i = 0; i < next_batch.block_descs.GetCount(); ++i) {
+      Index_t lambda_idx = std::numeric_limits<Index_t>::max();
+      const auto* program_data = mem_pool_acc[0].derefHandle(program);
+      for (Index_t j = 0; j < program.GetCount(); ++j) {
+        if (program_data[j].instructions == block_metadata[i].instructions) {
+          lambda_idx = j;
+          break;
+        }
+      }
+      std::cout << " block: num threads " << block_metadata[i].num_threads << " for lambda " << lambda_idx << std::endl;
+    }*/
     return next_batch;
   }
   if (next_batch.block_descs.GetCount() != 1) {
@@ -169,6 +185,9 @@ void Evaluator::run_eval_step(
                                                                block);
               });
           // TODO deallocate block if all complete in thread.
+          if (thread_idx == 0) {
+            *mem_pool_write[0].derefHandle(block_meta.block) = local_block[0];
+          }
         });
   });
 }

--- a/Core/EvaluatorV2/Evaluator.cpp
+++ b/Core/EvaluatorV2/Evaluator.cpp
@@ -98,22 +98,6 @@ auto Evaluator::schedule_next_batch(const Program program)
   const auto next_batch = IndirectCallHandlerType::create_block_exec_group(
       work_queue_, mem_pool_buffer_, indirect_call_handler_buffer_, program);
   if (next_batch.block_descs.GetCount() > 1) {
-    /*std::cout << "Multiple blocks returned" << std::endl;
-    auto mem_pool_acc =
-    mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(); const
-    auto* block_metadata = mem_pool_acc[0].derefHandle(next_batch.block_descs);
-    for (Index_t i = 0; i < next_batch.block_descs.GetCount(); ++i) {
-      Index_t lambda_idx = std::numeric_limits<Index_t>::max();
-      const auto* program_data = mem_pool_acc[0].derefHandle(program);
-      for (Index_t j = 0; j < program.GetCount(); ++j) {
-        if (program_data[j].instructions == block_metadata[i].instructions) {
-          lambda_idx = j;
-          break;
-        }
-      }
-      std::cout << " block: num threads " << block_metadata[i].num_threads << "
-    for lambda " << lambda_idx << std::endl;
-    }*/
     return next_batch;
   }
   if (next_batch.block_descs.GetCount() != 1) {

--- a/Core/EvaluatorV2/Evaluator.cpp
+++ b/Core/EvaluatorV2/Evaluator.cpp
@@ -7,25 +7,31 @@
 namespace FunGPU::EvaluatorV2 {
 Evaluator::Evaluator(cl::sycl::buffer<PortableMemPool> buffer)
     : mem_pool_buffer_(buffer) {
-   std::cout
-        << "Running on "
-        << work_queue_.get_device().get_info<cl::sycl::info::device::name>()
-        << ", block size: " << sizeof(RuntimeBlockType) << std::endl;
+  std::cout << "Running on "
+            << work_queue_.get_device().get_info<cl::sycl::info::device::name>()
+            << ", block size: " << sizeof(RuntimeBlockType) << std::endl;
 }
 
 RuntimeValue Evaluator::compute(const Program program) {
   first_block_ = construct_initial_block(program);
-  work_queue_.submit([&](cl::sycl::handler& cgh) {
-    auto indirect_call_acc = indirect_call_handler_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
-    auto mem_pool_acc = mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
+  work_queue_.submit([&](cl::sycl::handler &cgh) {
+    auto indirect_call_acc =
+        indirect_call_handler_buffer_
+            .get_access<cl::sycl::access::mode::read_write>(cgh);
+    auto mem_pool_acc =
+        mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
     const auto first_block_tmp = first_block_;
-    cgh.single_task([indirect_call_acc, mem_pool_acc, first_block_tmp, program] {
-      indirect_call_acc[0].update_for_num_lambdas(mem_pool_acc, program.GetCount());
-      FunctionValue funv;
-      funv.block_idx = 0;
-      funv.captures = PortableMemPool::ArrayHandle<RuntimeValue>();
-      indirect_call_acc[0].on_indirect_call(mem_pool_acc, first_block_tmp, funv, 0, 0, PortableMemPool::ArrayHandle<RuntimeValue>());
-    });
+    cgh.single_task(
+        [indirect_call_acc, mem_pool_acc, first_block_tmp, program] {
+          indirect_call_acc[0].update_for_num_lambdas(mem_pool_acc,
+                                                      program.GetCount());
+          FunctionValue funv;
+          funv.block_idx = 0;
+          funv.captures = PortableMemPool::ArrayHandle<RuntimeValue>();
+          indirect_call_acc[0].on_indirect_call(
+              mem_pool_acc, first_block_tmp, funv, 0, 0,
+              PortableMemPool::ArrayHandle<RuntimeValue>());
+        });
   });
 
   while (true) {
@@ -41,16 +47,20 @@ RuntimeValue Evaluator::compute(const Program program) {
 
 auto Evaluator::construct_initial_block(const Program program)
     -> PortableMemPool::Handle<RuntimeBlockType> {
-  cl::sycl::buffer<PortableMemPool::Handle<RuntimeBlockType>> initial_block_buf(cl::sycl::range<1>(1));
-  work_queue_.submit([&] (cl::sycl::handler &cgh) {
-    auto result_acc = initial_block_buf.get_access<cl::sycl::access::mode::discard_write>(cgh);
+  cl::sycl::buffer<PortableMemPool::Handle<RuntimeBlockType>> initial_block_buf(
+      cl::sycl::range<1>(1));
+  work_queue_.submit([&](cl::sycl::handler &cgh) {
+    auto result_acc =
+        initial_block_buf.get_access<cl::sycl::access::mode::discard_write>(
+            cgh);
     auto mem_pool_acc =
-      mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
+        mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
     cgh.single_task([result_acc, mem_pool_acc, program] {
       const auto &main_lambda = mem_pool_acc[0].derefHandle(program)[0];
-      const auto block = mem_pool_acc[0].Alloc<RuntimeBlockType>(main_lambda.instructions, 1);
+      const auto block =
+          mem_pool_acc[0].Alloc<RuntimeBlockType>(main_lambda.instructions, 1);
       result_acc[0] = block;
-      auto& block_data = *mem_pool_acc[0].derefHandle(block);
+      auto &block_data = *mem_pool_acc[0].derefHandle(block);
       block_data.num_outstanding_dependencies = 1;
     });
   });
@@ -58,22 +68,26 @@ auto Evaluator::construct_initial_block(const Program program)
   return initial_block_buf.get_access<cl::sycl::access::mode::read>()[0];
 }
 
-RuntimeValue Evaluator::read_result(const PortableMemPool::Handle<RuntimeBlockType> first_block) {
+RuntimeValue Evaluator::read_result(
+    const PortableMemPool::Handle<RuntimeBlockType> first_block) {
   cl::sycl::buffer<RuntimeValue> result(cl::sycl::range<1>(1));
-  work_queue_.submit([&](cl::sycl::handler& cgh) {
+  work_queue_.submit([&](cl::sycl::handler &cgh) {
     auto mem_pool_acc =
-      mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
-    auto result_acc = result.get_access<cl::sycl::access::mode::discard_write>(cgh);
+        mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
+    auto result_acc =
+        result.get_access<cl::sycl::access::mode::discard_write>(cgh);
     cgh.single_task([mem_pool_acc, result_acc, first_block] {
-      const auto& first_block_data = *mem_pool_acc[0].derefHandle(first_block);
+      const auto &first_block_data = *mem_pool_acc[0].derefHandle(first_block);
       result_acc[0] = first_block_data.registers[0][0];
     });
   });
   return result.get_access<cl::sycl::access::mode::read>()[0];
 }
 
-auto Evaluator::schedule_next_batch(const Program program) -> std::optional<RuntimeBlockType::BlockExecGroup> {
-  const auto next_batch = IndirectCallHandlerType::create_block_exec_group(work_queue_, mem_pool_buffer_, indirect_call_handler_buffer_, program);
+auto Evaluator::schedule_next_batch(const Program program)
+    -> std::optional<RuntimeBlockType::BlockExecGroup> {
+  const auto next_batch = IndirectCallHandlerType::create_block_exec_group(
+      work_queue_, mem_pool_buffer_, indirect_call_handler_buffer_, program);
   if (next_batch.block_descs.GetCount() > 1) {
     return next_batch;
   }
@@ -81,68 +95,81 @@ auto Evaluator::schedule_next_batch(const Program program) -> std::optional<Runt
     throw std::invalid_argument("Expected at least one block");
   }
   cl::sycl::buffer<bool> is_initial_block_ready_again(cl::sycl::range<1>(1));
-  work_queue_.submit([&](cl::sycl::handler& cgh) {
-    auto mem_pool_acc = mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
-    auto result_acc = is_initial_block_ready_again.get_access<cl::sycl::access::mode::discard_write>(cgh);
+  work_queue_.submit([&](cl::sycl::handler &cgh) {
+    auto mem_pool_acc =
+        mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
+    auto result_acc =
+        is_initial_block_ready_again
+            .get_access<cl::sycl::access::mode::discard_write>(cgh);
     const auto first_block_tmp = first_block_;
-    cgh.single_task([mem_pool_acc, next_batch, is_initial_block_ready_again, first_block_tmp, result_acc] {
-      const auto& block_meta = mem_pool_acc[0].derefHandle((next_batch.block_descs))[0];
+    cgh.single_task([mem_pool_acc, next_batch, is_initial_block_ready_again,
+                     first_block_tmp, result_acc] {
+      const auto &block_meta =
+          mem_pool_acc[0].derefHandle((next_batch.block_descs))[0];
       result_acc[0] = block_meta.block == first_block_tmp;
     });
   });
-  if (is_initial_block_ready_again.get_access<cl::sycl::access::mode::read>()[0]) {
+  if (is_initial_block_ready_again
+          .get_access<cl::sycl::access::mode::read>()[0]) {
     return std::nullopt;
   }
   return next_batch;
 }
 
-void Evaluator::run_eval_step(const RuntimeBlockType::BlockExecGroup block_group) {
-   work_queue_.submit([&](cl::sycl::handler &cgh) {
-      auto mem_pool_write =
-          mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
-      auto indirect_call_handler_acc = indirect_call_handler_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
-      cl::sycl::accessor<RuntimeBlockType, 1,
-                         cl::sycl::access::mode::read_write,
-                         cl::sycl::access::target::local>
-          local_block(cl::sycl::range<1>(1), cgh);
-      RuntimeBlockType::InstructionLocalMemAccessor local_instructions(
-          cl::sycl::range<2>(block_group.block_descs.GetCount(),
-                             block_group.max_num_instructions),
-          cgh);
-      cgh.parallel_for<class TestEvalLoop>(
-          cl::sycl::nd_range<1>(THREADS_PER_BLOCK *
-                                    block_group.block_descs.GetCount(),
-                                THREADS_PER_BLOCK),
-          [mem_pool_write, block_group, local_block, local_instructions, indirect_call_handler_acc](cl::sycl::nd_item<1> itm) {
-            const auto thread_idx = itm.get_local_linear_id();
-            const auto block_idx = itm.get_group_linear_id();
-            const auto block_meta = mem_pool_write[0].derefHandle(
-                block_group.block_descs)[block_idx];
-            if (thread_idx == 0) {
-              local_block[0] = *mem_pool_write[0].derefHandle(block_meta.block);
-            }
-            const auto *instructions_global_data =
-                mem_pool_write[0].derefHandle(block_meta.instructions);
-            auto instructions_for_block = local_instructions[block_idx];
-            for (auto idx = thread_idx;
-                 idx < block_meta.instructions.GetCount();
-                 idx += THREADS_PER_BLOCK) {
-              instructions_for_block[idx] = instructions_global_data[idx];
-            }
-            itm.barrier();
-            if (thread_idx >= block_meta.num_threads) {
-              return;
-            }
-            RuntimeBlockType::Status status = local_block[0].evaluate(
-                block_idx, thread_idx, mem_pool_write, local_instructions,
-                block_meta.instructions.GetCount(), [indirect_call_handler_acc, mem_pool_write](const auto block, const auto funv, const auto tid, const auto reg, const auto args) {
-                  indirect_call_handler_acc[0].on_indirect_call(mem_pool_write, block, funv, tid, reg, args);
-                },
-                [indirect_call_handler_acc, mem_pool_write](const auto block) {
-                  indirect_call_handler_acc[0].on_activate_block(mem_pool_write, block);
-                });
-            // TODO deallocate block if all complete in thread.
-          });
-    });
+void Evaluator::run_eval_step(
+    const RuntimeBlockType::BlockExecGroup block_group) {
+  work_queue_.submit([&](cl::sycl::handler &cgh) {
+    auto mem_pool_write =
+        mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
+    auto indirect_call_handler_acc =
+        indirect_call_handler_buffer_
+            .get_access<cl::sycl::access::mode::read_write>(cgh);
+    cl::sycl::accessor<RuntimeBlockType, 1, cl::sycl::access::mode::read_write,
+                       cl::sycl::access::target::local>
+        local_block(cl::sycl::range<1>(1), cgh);
+    RuntimeBlockType::InstructionLocalMemAccessor local_instructions(
+        cl::sycl::range<2>(block_group.block_descs.GetCount(),
+                           block_group.max_num_instructions),
+        cgh);
+    cgh.parallel_for<class TestEvalLoop>(
+        cl::sycl::nd_range<1>(THREADS_PER_BLOCK *
+                                  block_group.block_descs.GetCount(),
+                              THREADS_PER_BLOCK),
+        [mem_pool_write, block_group, local_block, local_instructions,
+         indirect_call_handler_acc](cl::sycl::nd_item<1> itm) {
+          const auto thread_idx = itm.get_local_linear_id();
+          const auto block_idx = itm.get_group_linear_id();
+          const auto block_meta =
+              mem_pool_write[0].derefHandle(block_group.block_descs)[block_idx];
+          if (thread_idx == 0) {
+            local_block[0] = *mem_pool_write[0].derefHandle(block_meta.block);
+          }
+          const auto *instructions_global_data =
+              mem_pool_write[0].derefHandle(block_meta.instructions);
+          auto instructions_for_block = local_instructions[block_idx];
+          for (auto idx = thread_idx; idx < block_meta.instructions.GetCount();
+               idx += THREADS_PER_BLOCK) {
+            instructions_for_block[idx] = instructions_global_data[idx];
+          }
+          itm.barrier();
+          if (thread_idx >= block_meta.num_threads) {
+            return;
+          }
+          RuntimeBlockType::Status status = local_block[0].evaluate(
+              block_idx, thread_idx, mem_pool_write, local_instructions,
+              block_meta.instructions.GetCount(),
+              [indirect_call_handler_acc, mem_pool_write](
+                  const auto block, const auto funv, const auto tid,
+                  const auto reg, const auto args) {
+                indirect_call_handler_acc[0].on_indirect_call(
+                    mem_pool_write, block, funv, tid, reg, args);
+              },
+              [indirect_call_handler_acc, mem_pool_write](const auto block) {
+                indirect_call_handler_acc[0].on_activate_block(mem_pool_write,
+                                                               block);
+              });
+          // TODO deallocate block if all complete in thread.
+        });
+  });
 }
 } // namespace FunGPU::EvaluatorV2

--- a/Core/EvaluatorV2/Evaluator.cpp
+++ b/Core/EvaluatorV2/Evaluator.cpp
@@ -1,55 +1,148 @@
-#include "Core/Evaluator.hpp"
+#include "Core/EvaluatorV2/Evaluator.hpp"
+#include "Core/EvaluatorV2/RuntimeBlock.hpp"
+#include "Core/EvaluatorV2/RuntimeValue.h"
+#include "Core/PortableMemPool.hpp"
+#include <stdexcept>
 
 namespace FunGPU::EvaluatorV2 {
-RuntimeBlockHandle
-Evaluator::DependencyAggregator::runtime_block(const Index_t index) {
-  return buffers[cur_buffer_idx_][index];
-}
-
-void Evaluator::DependencyAggregator::add_block(
-    const RuntimeBlockHandle handle) {
-  cl::sycl::atomic<int> atomic_num_active_blocks(
-      (cl::sycl::multi_ptr<int, cl::sycl::access::address_space::global_space>(
-          num_active_blocks_)));
-  const auto reserved_idx = atomic_num_active_blocks.fetch_add(1);
-  buffers_[cur_buffer_idx_ & 1][reserved_idx] = handle;
-}
-
-Index_t Evaluator::DependencyAggregator::flip() {
-  ++cur_buffer_idx_;
-  const auto prev_num_active_blocks = num_active_blocks_;
-  num_active_blocks_ = 0;
-  return prev_num_active_blocks;
-}
-
 Evaluator::Evaluator(cl::sycl::buffer<PortableMemPool> buffer)
-    : mem_pool_buffer_(buffer) {}
-
-auto Evaluator::construct_initial_block(const Program &program)
-    -> RuntimeBlockHandle {
-  auto mem_pool_acc =
-      mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>();
-  const auto &main_lambda = mem_pool_acc[0].derefHandle(program)[0];
-  auto main_block_handle = mem_pool_acc[0].alloc<RuntimeBlock_t>(main_lambda);
-  return mem_pool_acc[0].derefHandle(main_block_handle);
+    : mem_pool_buffer_(buffer) {
+   std::cout
+        << "Running on "
+        << work_queue_.get_device().get_info<cl::sycl::info::device::name>()
+        << ", block size: " << sizeof(RuntimeBlockType) << std::endl;
 }
 
-RuntimeValue Evaluator::read_result(const RuntimeBlockHandle first_block,
-                                    const Program &program) {
-  auto mem_pool_acc =
-      mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>();
-  const auto &main_lambda = mem_pool_acc[0].derefHandle(program)[0];
-  const auto &block = mem_pool_acc[0].derefHandle(first_block);
-  return block.result(0, main_lambda);
-}
-
-RuntimeValue Evaluator::compute(const Program &program) {
-  auto first_block = construct_initial_block(program);
+RuntimeValue Evaluator::compute(const Program program) {
+  first_block_ = construct_initial_block(program);
+  work_queue_.submit([&](cl::sycl::handler& cgh) {
+    auto indirect_call_acc = indirect_call_handler_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
+    auto mem_pool_acc = mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
+    const auto first_block_tmp = first_block_;
+    cgh.single_task([indirect_call_acc, mem_pool_acc, first_block_tmp, program] {
+      indirect_call_acc[0].update_for_num_lambdas(mem_pool_acc, program.GetCount());
+      FunctionValue funv;
+      funv.block_idx = 0;
+      funv.captures = PortableMemPool::ArrayHandle<RuntimeValue>();
+      indirect_call_acc[0].on_indirect_call(mem_pool_acc, first_block_tmp, funv, 0, 0, PortableMemPool::ArrayHandle<RuntimeValue>());
+    });
+  });
 
   while (true) {
-    // break if first_block becomes ready again and is complete
+    const auto maybe_next_batch = schedule_next_batch(program);
+    if (!maybe_next_batch.has_value()) {
+      break;
+    }
+    run_eval_step(*maybe_next_batch);
   }
 
-  return read_result(first_block, program);
+  return read_result(first_block_);
+}
+
+auto Evaluator::construct_initial_block(const Program program)
+    -> PortableMemPool::Handle<RuntimeBlockType> {
+  cl::sycl::buffer<PortableMemPool::Handle<RuntimeBlockType>> initial_block_buf(cl::sycl::range<1>(1));
+  work_queue_.submit([&] (cl::sycl::handler &cgh) {
+    auto result_acc = initial_block_buf.get_access<cl::sycl::access::mode::discard_write>(cgh);
+    auto mem_pool_acc =
+      mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
+    cgh.single_task([result_acc, mem_pool_acc, program] {
+      const auto &main_lambda = mem_pool_acc[0].derefHandle(program)[0];
+      const auto block = mem_pool_acc[0].Alloc<RuntimeBlockType>(main_lambda.instructions, 1);
+      result_acc[0] = block;
+      auto& block_data = *mem_pool_acc[0].derefHandle(block);
+      block_data.num_outstanding_dependencies = 1;
+    });
+  });
+
+  return initial_block_buf.get_access<cl::sycl::access::mode::read>()[0];
+}
+
+RuntimeValue Evaluator::read_result(const PortableMemPool::Handle<RuntimeBlockType> first_block) {
+  cl::sycl::buffer<RuntimeValue> result(cl::sycl::range<1>(1));
+  work_queue_.submit([&](cl::sycl::handler& cgh) {
+    auto mem_pool_acc =
+      mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
+    auto result_acc = result.get_access<cl::sycl::access::mode::discard_write>(cgh);
+    cgh.single_task([mem_pool_acc, result_acc, first_block] {
+      const auto& first_block_data = *mem_pool_acc[0].derefHandle(first_block);
+      result_acc[0] = first_block_data.registers[0][0];
+    });
+  });
+  return result.get_access<cl::sycl::access::mode::read>()[0];
+}
+
+auto Evaluator::schedule_next_batch(const Program program) -> std::optional<RuntimeBlockType::BlockExecGroup> {
+  const auto next_batch = IndirectCallHandlerType::create_block_exec_group(work_queue_, mem_pool_buffer_, indirect_call_handler_buffer_, program);
+  if (next_batch.block_descs.GetCount() > 1) {
+    return next_batch;
+  }
+  if (next_batch.block_descs.GetCount() != 1) {
+    throw std::invalid_argument("Expected at least one block");
+  }
+  cl::sycl::buffer<bool> is_initial_block_ready_again(cl::sycl::range<1>(1));
+  work_queue_.submit([&](cl::sycl::handler& cgh) {
+    auto mem_pool_acc = mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
+    auto result_acc = is_initial_block_ready_again.get_access<cl::sycl::access::mode::discard_write>(cgh);
+    const auto first_block_tmp = first_block_;
+    cgh.single_task([mem_pool_acc, next_batch, is_initial_block_ready_again, first_block_tmp, result_acc] {
+      const auto& block_meta = mem_pool_acc[0].derefHandle((next_batch.block_descs))[0];
+      result_acc[0] = block_meta.block == first_block_tmp;
+    });
+  });
+  if (is_initial_block_ready_again.get_access<cl::sycl::access::mode::read>()[0]) {
+    return std::nullopt;
+  }
+  return next_batch;
+}
+
+void Evaluator::run_eval_step(const RuntimeBlockType::BlockExecGroup block_group) {
+   work_queue_.submit([&](cl::sycl::handler &cgh) {
+      auto mem_pool_write =
+          mem_pool_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
+      auto indirect_call_handler_acc = indirect_call_handler_buffer_.get_access<cl::sycl::access::mode::read_write>(cgh);
+      cl::sycl::accessor<RuntimeBlockType, 1,
+                         cl::sycl::access::mode::read_write,
+                         cl::sycl::access::target::local>
+          local_block(cl::sycl::range<1>(1), cgh);
+      RuntimeBlockType::InstructionLocalMemAccessor local_instructions(
+          cl::sycl::range<2>(block_group.block_descs.GetCount(),
+                             block_group.max_num_instructions),
+          cgh);
+      cgh.parallel_for<class TestEvalLoop>(
+          cl::sycl::nd_range<1>(THREADS_PER_BLOCK *
+                                    block_group.block_descs.GetCount(),
+                                THREADS_PER_BLOCK),
+          [mem_pool_write, block_group, local_block, local_instructions, indirect_call_handler_acc](cl::sycl::nd_item<1> itm) {
+            const auto thread_idx = itm.get_local_linear_id();
+            const auto block_idx = itm.get_group_linear_id();
+            const auto block_meta = mem_pool_write[0].derefHandle(
+                block_group.block_descs)[block_idx];
+            if (thread_idx == 0) {
+              local_block[0] = *mem_pool_write[0].derefHandle(block_meta.block);
+            }
+            const auto *instructions_global_data =
+                mem_pool_write[0].derefHandle(block_meta.instructions);
+            auto instructions_for_block = local_instructions[block_idx];
+            for (auto idx = thread_idx;
+                 idx < block_meta.instructions.GetCount();
+                 idx += THREADS_PER_BLOCK) {
+              instructions_for_block[idx] = instructions_global_data[idx];
+            }
+            itm.barrier();
+            if (thread_idx >= block_meta.num_threads) {
+              return;
+            }
+            RuntimeBlockType::Status status = local_block[0].evaluate(
+                block_idx, thread_idx, mem_pool_write, local_instructions,
+                block_meta.instructions.GetCount(), [indirect_call_handler_acc, mem_pool_write](const auto block, const auto funv, const auto tid, const auto reg, const auto args) {
+                  indirect_call_handler_acc[0].on_indirect_call(mem_pool_write, block, funv, tid, reg, args);
+                },
+                [indirect_call_handler_acc, mem_pool_write](const auto block) {
+                  indirect_call_handler_acc[0].on_activate_block(mem_pool_write, block);
+                });
+            // TODO deallocate block if all complete in thread.
+          });
+    });
 }
 } // namespace FunGPU::EvaluatorV2

--- a/Core/EvaluatorV2/Evaluator.hpp
+++ b/Core/EvaluatorV2/Evaluator.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include "Core/EvaluatorV2/IndirectCallHandler.hpp"
 #include "Core/EvaluatorV2/Program.hpp"
 #include "Core/EvaluatorV2/RuntimeBlock.hpp"
 #include "Core/EvaluatorV2/RuntimeValue.h"
 #include "Core/PortableMemPool.hpp"
 #include "Core/sycl.hpp"
-#include "Core/EvaluatorV2/IndirectCallHandler.hpp"
 #include "sycl/queue.hpp"
 #include <optional>
 
@@ -14,8 +14,10 @@ class Evaluator {
 public:
   static constexpr Index_t REGISTERS_PER_THREAD = 64;
   static constexpr Index_t THREADS_PER_BLOCK = 32;
-  using RuntimeBlockType = RuntimeBlock<REGISTERS_PER_THREAD, THREADS_PER_BLOCK>;
-  using IndirectCallHandlerType = IndirectCallHandler<RuntimeBlockType, 4096, 4096>;
+  using RuntimeBlockType =
+      RuntimeBlock<REGISTERS_PER_THREAD, THREADS_PER_BLOCK>;
+  using IndirectCallHandlerType =
+      IndirectCallHandler<RuntimeBlockType, 4096, 4096>;
 
   Evaluator(cl::sycl::buffer<PortableMemPool>);
   RuntimeValue compute(Program);
@@ -25,12 +27,13 @@ private:
   RuntimeValue read_result(PortableMemPool::Handle<RuntimeBlockType>);
 
   void run_eval_step(RuntimeBlockType::BlockExecGroup);
-  std::optional<RuntimeBlockType::BlockExecGroup> schedule_next_batch(
-    Program);
+  std::optional<RuntimeBlockType::BlockExecGroup> schedule_next_batch(Program);
 
   cl::sycl::buffer<PortableMemPool> mem_pool_buffer_;
-  std::shared_ptr<IndirectCallHandlerType> indirect_call_handler_data_ = std::make_shared<IndirectCallHandlerType>();
-  cl::sycl::buffer<IndirectCallHandlerType> indirect_call_handler_buffer_{indirect_call_handler_data_, cl::sycl::range<1>(1)};
+  std::shared_ptr<IndirectCallHandlerType> indirect_call_handler_data_ =
+      std::make_shared<IndirectCallHandlerType>();
+  cl::sycl::buffer<IndirectCallHandlerType> indirect_call_handler_buffer_{
+      indirect_call_handler_data_, cl::sycl::range<1>(1)};
   PortableMemPool::Handle<RuntimeBlockType> first_block_;
   cl::sycl::queue work_queue_;
 };

--- a/Core/EvaluatorV2/FunGPUV2.cpp
+++ b/Core/EvaluatorV2/FunGPUV2.cpp
@@ -1,6 +1,6 @@
 #include "Core/EvaluatorV2/CompileProgram.hpp"
-#include "Core/PortableMemPool.hpp"
 #include "Core/EvaluatorV2/Evaluator.hpp"
+#include "Core/PortableMemPool.hpp"
 #include <iostream>
 
 using namespace FunGPU;
@@ -10,11 +10,11 @@ int main(int argc, char **argv) {
   auto mem_pool = std::make_shared<PortableMemPool>();
   try {
     cl::sycl::buffer<PortableMemPool> mem_pool_buffer(mem_pool,
-                                                  cl::sycl::range<1>(1));
+                                                      cl::sycl::range<1>(1));
     Evaluator evaluator(mem_pool_buffer);
     Index_t argvIndex = 1;
     while (true) {
-     const auto program_path = [&]() -> std::optional<std::string> {
+      const auto program_path = [&]() -> std::optional<std::string> {
         if (argvIndex < argc) {
           return std::string(argv[argvIndex++]);
         }
@@ -30,8 +30,9 @@ int main(int argc, char **argv) {
       if (!program_path) {
         break;
       }
-      const auto program = compile_program(*program_path, Evaluator::REGISTERS_PER_THREAD,
-                        Evaluator::THREADS_PER_BLOCK, mem_pool_buffer);
+      const auto program =
+          compile_program(*program_path, Evaluator::REGISTERS_PER_THREAD,
+                          Evaluator::THREADS_PER_BLOCK, mem_pool_buffer);
       const auto result = evaluator.compute(program);
       std::cout << "Result: " << result.data.float_val << std::endl;
     }

--- a/Core/EvaluatorV2/FunGPUV2.cpp
+++ b/Core/EvaluatorV2/FunGPUV2.cpp
@@ -1,0 +1,42 @@
+#include "Core/EvaluatorV2/CompileProgram.hpp"
+#include "Core/PortableMemPool.hpp"
+#include "Core/EvaluatorV2/Evaluator.hpp"
+#include <iostream>
+
+using namespace FunGPU;
+using namespace FunGPU::EvaluatorV2;
+
+int main(int argc, char **argv) {
+  auto mem_pool = std::make_shared<PortableMemPool>();
+  try {
+    cl::sycl::buffer<PortableMemPool> mem_pool_buffer(mem_pool,
+                                                  cl::sycl::range<1>(1));
+    Evaluator evaluator(mem_pool_buffer);
+    Index_t argvIndex = 1;
+    while (true) {
+     const auto program_path = [&]() -> std::optional<std::string> {
+        if (argvIndex < argc) {
+          return std::string(argv[argvIndex++]);
+        }
+
+        std::cout << "Program to run(or q to quit): ";
+        std::string interactivePath;
+        std::cin >> interactivePath;
+        if (interactivePath == "q") {
+          return std::optional<std::string>();
+        }
+        return interactivePath;
+      }();
+      if (!program_path) {
+        break;
+      }
+      const auto program = compile_program(*program_path, Evaluator::REGISTERS_PER_THREAD,
+                        Evaluator::THREADS_PER_BLOCK, mem_pool_buffer);
+      const auto result = evaluator.compute(program);
+      std::cout << "Result: " << result.data.float_val << std::endl;
+    }
+  } catch (const cl::sycl::exception &e) {
+    std::cerr << "Sycl exception in main: " << e.what() << std::endl;
+  }
+  return 0;
+}

--- a/Core/EvaluatorV2/IndirectCallHandler.hpp
+++ b/Core/EvaluatorV2/IndirectCallHandler.hpp
@@ -330,8 +330,8 @@ IndirectCallHandler<RuntimeBlockType, MaxNumIndirectCalls,
         });
   });
   // Fill indirect call request blocks
-  const auto max_num_threads_per_lambda_val = max_num_threads_per_lambda
-                               .get_access<cl::sycl::access::mode::read>()[0];
+  const auto max_num_threads_per_lambda_val =
+      max_num_threads_per_lambda.get_access<cl::sycl::access::mode::read>()[0];
   if (max_num_threads_per_lambda_val == 0) {
     throw std::invalid_argument("No threads across any lambdas");
   }
@@ -345,8 +345,7 @@ IndirectCallHandler<RuntimeBlockType, MaxNumIndirectCalls,
         indirect_call_handler
             .template get_access<cl::sycl::access::mode::read_write>(cgh);
     cgh.parallel_for<class InitBlocksPerThread>(
-        cl::sycl::range<2>(program.GetCount(),
-                           max_num_threads_per_lambda_val),
+        cl::sycl::range<2>(program.GetCount(), max_num_threads_per_lambda_val),
         [mem_pool_write, block_exec_group_per_lambda_acc,
          indirect_call_handler_acc](const cl::sycl::item<2> itm) {
           indirect_call_handler_acc[0].setup_block(
@@ -389,10 +388,10 @@ IndirectCallHandler<RuntimeBlockType, MaxNumIndirectCalls,
     auto copy_begin_atomic_acc =
         copy_begin_idx.template get_access<cl::sycl::access::mode::atomic>(cgh);
     cgh.parallel_for<class MergeIntoResult>(
-        cl::sycl::range<2>(
-            program.GetCount() + 1,
-            (max_num_threads_per_lambda_val + RuntimeBlockType::NumThreadsPerBlock - 1)  /
-                RuntimeBlockType::NumThreadsPerBlock),
+        cl::sycl::range<2>(program.GetCount() + 1,
+                           (max_num_threads_per_lambda_val +
+                            RuntimeBlockType::NumThreadsPerBlock - 1) /
+                               RuntimeBlockType::NumThreadsPerBlock),
         [mem_pool_write, result_acc, block_exec_group_per_lambda_acc,
          copy_begin_atomic_acc](cl::sycl::item<2> itm) {
           auto *target_block_descs =

--- a/Core/EvaluatorV2/IndirectCallHandler.hpp
+++ b/Core/EvaluatorV2/IndirectCallHandler.hpp
@@ -49,11 +49,7 @@ public:
     Index_t num_runtime_blocks_reactivated = 0;
   };
 
-  IndirectCallHandler(PortableMemPool::HostAccessor_t mem_pool_acc,
-                      const Index_t num_lambdas)
-      : indirect_call_requests_by_block(
-            mem_pool_acc[0].AllocArray<IndirectCallRequestBuffer>(
-                num_lambdas)) {}
+  void update_for_num_lambdas(PortableMemPool::DeviceAccessor_t, Index_t num_lambdas);
 
   static typename RuntimeBlockType::BlockExecGroup
   create_block_exec_group(cl::sycl::queue &,
@@ -82,6 +78,18 @@ public:
       indirect_call_requests_by_block;
   BlockReactivationRequestBuffer block_reactivation_requests_by_block;
 };
+
+template <typename RuntimeBlockType, Index_t MaxNumIndirectCalls,
+          Index_t MaxNumReactivations>
+void IndirectCallHandler<RuntimeBlockType, MaxNumIndirectCalls,
+                    MaxNumReactivations>::update_for_num_lambdas(PortableMemPool::DeviceAccessor_t mem_pool_acc, 
+                    const Index_t num_lambdas) {
+  if (num_lambdas != indirect_call_requests_by_block.GetCount()) {
+    mem_pool_acc[0].DeallocArray(indirect_call_requests_by_block);
+    indirect_call_requests_by_block = mem_pool_acc[0].AllocArray<IndirectCallRequestBuffer>(
+              num_lambdas);
+  }
+}
 
 template <typename RuntimeBlockType, Index_t MaxNumIndirectCalls,
           Index_t MaxNumReactivations>

--- a/Core/EvaluatorV2/Instruction.cpp
+++ b/Core/EvaluatorV2/Instruction.cpp
@@ -12,71 +12,73 @@ Instruction::print(PortableMemPool::HostAccessor_t mem_pool_acc) const {
            << " " << #OP << " " << elem.rhs;                                   \
   }
 
-  const auto print_call_indirect_like = [&](const auto& call_indirect) {
-    const auto is_blocking = std::is_same_v<std::remove_cvref_t<decltype(call_indirect)>, BlockingCallIndirect>;
+  const auto print_call_indirect_like = [&](const auto &call_indirect) {
+    const auto is_blocking =
+        std::is_same_v<std::remove_cvref_t<decltype(call_indirect)>,
+                       BlockingCallIndirect>;
     if (is_blocking) {
       result << "Blocking";
     }
-     result << "CallIndirect: reg " << call_indirect.target_register
-                   << " = call reg " << call_indirect.lambda_idx
-                   << ", arg registers ";
-            const auto *arg_regs =
-                mem_pool_acc[0].derefHandle(call_indirect.arg_indices.unpack());
-            for (Index_t i = 0;
-                 i < call_indirect.arg_indices.unpack().GetCount(); ++i) {
-              result << arg_regs[i] << ", ";
-            }
+    result << "CallIndirect: reg " << call_indirect.target_register
+           << " = call reg " << call_indirect.lambda_idx << ", arg registers ";
+    const auto *arg_regs =
+        mem_pool_acc[0].derefHandle(call_indirect.arg_indices.unpack());
+    for (Index_t i = 0; i < call_indirect.arg_indices.unpack().GetCount();
+         ++i) {
+      result << arg_regs[i] << ", ";
+    }
   };
 
-  visit(
-      *this,
-      Visitor{
-          [&](const CreateLambda &create_lambda) {
-            result << "CreateLambda: reg " << create_lambda.target_register
-                   << " = " << create_lambda.block_idx
-                   << ", capture registers ";
-            const auto *captured_indices = mem_pool_acc[0].derefHandle(
-                create_lambda.captured_indices.unpack());
-            for (Index_t i = 0;
-                 i < create_lambda.captured_indices.unpack().GetCount(); ++i) {
-              result << captured_indices[i] << ", ";
-            }
-          },
-          [&](const AssignConstant &assign_constant) {
-            result << "AssignConstant: reg " << assign_constant.target_register
-                   << " = " << assign_constant.constant;
-          },
-          [&](const Assign &assign) {
-            result << "Assign: reg " << assign.target_register << " = "
-                   << assign.source_register;
-          },
-          [&](const CallIndirect &call_indirect) {
-           print_call_indirect_like(call_indirect);
-          },
-          [&](const BlockingCallIndirect& call_indirect) {
-            print_call_indirect_like(call_indirect);
-          },
-          [&](const If &if_inst) {
-            result << "If reg " << if_inst.predicate << " goto "
-                   << if_inst.goto_true << " else " << if_inst.goto_false;
-          },
-          [&](const Floor &floor_inst) {
-            result << "Floor: reg " << floor_inst.target_register << " = foor("
-                   << floor_inst.arg << ")";
-          },
-          [&](const InstructionBarrier &) { result << "InstructionBarrier"; },
-          HANDLE_BINARY_OP(Add, +),
-          HANDLE_BINARY_OP(Sub, -),
-          HANDLE_BINARY_OP(Mul, *),
-          HANDLE_BINARY_OP(Div, /),
-          HANDLE_BINARY_OP(Equal, ==),
-          HANDLE_BINARY_OP(GreaterThan, >),
-          HANDLE_BINARY_OP(Remainder, remainder),
-          HANDLE_BINARY_OP(Expt, expt),
-      },
-      [](const auto &) {
-        throw std::invalid_argument("Unexpected instruction type");
-      });
+  visit(*this,
+        Visitor{
+            [&](const CreateLambda &create_lambda) {
+              result << "CreateLambda: reg " << create_lambda.target_register
+                     << " = " << create_lambda.block_idx
+                     << ", capture registers ";
+              const auto *captured_indices = mem_pool_acc[0].derefHandle(
+                  create_lambda.captured_indices.unpack());
+              for (Index_t i = 0;
+                   i < create_lambda.captured_indices.unpack().GetCount();
+                   ++i) {
+                result << captured_indices[i] << ", ";
+              }
+            },
+            [&](const AssignConstant &assign_constant) {
+              result << "AssignConstant: reg "
+                     << assign_constant.target_register << " = "
+                     << assign_constant.constant;
+            },
+            [&](const Assign &assign) {
+              result << "Assign: reg " << assign.target_register << " = "
+                     << assign.source_register;
+            },
+            [&](const CallIndirect &call_indirect) {
+              print_call_indirect_like(call_indirect);
+            },
+            [&](const BlockingCallIndirect &call_indirect) {
+              print_call_indirect_like(call_indirect);
+            },
+            [&](const If &if_inst) {
+              result << "If reg " << if_inst.predicate << " goto "
+                     << if_inst.goto_true << " else " << if_inst.goto_false;
+            },
+            [&](const Floor &floor_inst) {
+              result << "Floor: reg " << floor_inst.target_register
+                     << " = foor(" << floor_inst.arg << ")";
+            },
+            [&](const InstructionBarrier &) { result << "InstructionBarrier"; },
+            HANDLE_BINARY_OP(Add, +),
+            HANDLE_BINARY_OP(Sub, -),
+            HANDLE_BINARY_OP(Mul, *),
+            HANDLE_BINARY_OP(Div, /),
+            HANDLE_BINARY_OP(Equal, ==),
+            HANDLE_BINARY_OP(GreaterThan, >),
+            HANDLE_BINARY_OP(Remainder, remainder),
+            HANDLE_BINARY_OP(Expt, expt),
+        },
+        [](const auto &) {
+          throw std::invalid_argument("Unexpected instruction type");
+        });
 
   return result.str();
 #undef HANDLE_BINARY_OP
@@ -96,8 +98,10 @@ bool array_handles_equal(const PortableMemPool::ArrayHandle<T> lhs,
   return std::equal(lhs_data, lhs_data + lhs.GetCount(), rhs_data);
 }
 
-bool call_indirect_common_equals(PortableMemPool::HostAccessor_t& mem_pool_acc, const CallIndirectCommon& lhs, const CallIndirectCommon& rhs) {
-     return lhs.target_register == rhs.target_register &&
+bool call_indirect_common_equals(PortableMemPool::HostAccessor_t &mem_pool_acc,
+                                 const CallIndirectCommon &lhs,
+                                 const CallIndirectCommon &rhs) {
+  return lhs.target_register == rhs.target_register &&
          lhs.lambda_idx == rhs.lambda_idx &&
          array_handles_equal(lhs.arg_indices.unpack(), rhs.arg_indices.unpack(),
                              mem_pool_acc);
@@ -129,8 +133,9 @@ bool CallIndirect::equals(const CallIndirect &other,
   return call_indirect_common_equals(mem_pool_acc, *this, other);
 }
 
-bool BlockingCallIndirect::equals(const BlockingCallIndirect &other,
-                          PortableMemPool::HostAccessor_t &mem_pool_acc) const {
+bool BlockingCallIndirect::equals(
+    const BlockingCallIndirect &other,
+    PortableMemPool::HostAccessor_t &mem_pool_acc) const {
   return call_indirect_common_equals(mem_pool_acc, *this, other);
 }
 

--- a/Core/EvaluatorV2/Instruction.h
+++ b/Core/EvaluatorV2/Instruction.h
@@ -63,8 +63,10 @@ struct CallIndirect : public CallIndirectCommon {
 };
 
 struct BlockingCallIndirect : public CallIndirectCommon {
-  static constexpr InstructionType TYPE = InstructionType::BLOCKING_CALL_INDIRECT;
-  bool equals(const BlockingCallIndirect &, PortableMemPool::HostAccessor_t &) const;
+  static constexpr InstructionType TYPE =
+      InstructionType::BLOCKING_CALL_INDIRECT;
+  bool equals(const BlockingCallIndirect &,
+              PortableMemPool::HostAccessor_t &) const;
 };
 
 static_assert(std::is_standard_layout<CallIndirect>::value);

--- a/Core/EvaluatorV2/RuntimeBlock.hpp
+++ b/Core/EvaluatorV2/RuntimeBlock.hpp
@@ -23,12 +23,14 @@ public:
 
   struct BlockMetadata {
     BlockMetadata(const PortableMemPool::Handle<RuntimeBlock> block,
-                  const PortableMemPool::ArrayHandle<Instruction> instructions)
-        : block(block), instructions(instructions) {}
+                  const PortableMemPool::ArrayHandle<Instruction> instructions,
+                  const Index_t num_threads)
+        : block(block), instructions(instructions), num_threads(num_threads) {}
     BlockMetadata() = default;
 
     PortableMemPool::Handle<RuntimeBlock> block;
     PortableMemPool::ArrayHandle<Instruction> instructions;
+    Index_t num_threads;
   };
 
   struct BlockExecGroup {
@@ -50,8 +52,9 @@ public:
                          cl::sycl::access::target::local>;
 
   explicit RuntimeBlock(
-      const PortableMemPool::ArrayHandle<Instruction> instructions)
-      : instruction_ref(instructions) {}
+      const PortableMemPool::ArrayHandle<Instruction> instructions,
+      const Index_t num_threads)
+      : instruction_ref(instructions), num_threads(num_threads) {}
 
   template <typename OnIndirectCall, typename OnActivateBlock>
   Status evaluate(const Index_t block_idx, const Index_t thread,
@@ -74,7 +77,7 @@ public:
                        OnActivateBlock &&on_activate_block);
 
   BlockMetadata block_metadata() const {
-    return BlockMetadata(m_handle, instruction_ref);
+    return BlockMetadata(m_handle, instruction_ref, num_threads);
   }
 
   std::array<std::array<RuntimeValue, RegistersPerThread>, ThreadsPerBlock>
@@ -82,6 +85,7 @@ public:
   PortableMemPool::Handle<RuntimeBlock> m_handle;
   PortableMemPool::ArrayHandle<Instruction> instruction_ref;
   TargetAddress target_data[ThreadsPerBlock];
+  Index_t num_threads;
   int num_outstanding_dependencies = 0;
 };
 

--- a/Core/EvaluatorV2/tests/BlockGenerator.cpp
+++ b/Core/EvaluatorV2/tests/BlockGenerator.cpp
@@ -99,7 +99,7 @@ BOOST_FIXTURE_TEST_CASE(SimpleCallTest, Fixture) {
             CreateLambda{0, 1, PortableMemPool::ArrayHandle<Index_t>()}),
         create_instruction(AssignConstant{1, 42}),
         create_instruction(
-            CallIndirect{2, 0, portable_index_array_from_vector({1})})},
+            BlockingCallIndirect{2, 0, portable_index_array_from_vector({1})})},
        {create_instruction(Assign{1, 0})}});
 }
 
@@ -111,7 +111,7 @@ BOOST_FIXTURE_TEST_CASE(SimpleClosureTest, Fixture) {
             CreateLambda{1, 1, portable_index_array_from_vector({0})}),
         create_instruction(AssignConstant{2, 3}),
         create_instruction(
-            CallIndirect{3, 1, portable_index_array_from_vector({2})})},
+            BlockingCallIndirect{3, 1, portable_index_array_from_vector({2})})},
        {create_instruction(Add{2, 0, 1})}});
 }
 
@@ -124,7 +124,7 @@ BOOST_FIXTURE_TEST_CASE(CallMultiBinding, Fixture) {
         create_instruction(AssignConstant{2, 10}),
         create_instruction(AssignConstant{3, 9}),
         create_instruction(
-            CallIndirect{4, 1, portable_index_array_from_vector({3})})},
+            BlockingCallIndirect{4, 1, portable_index_array_from_vector({3})})},
        {create_instruction(Add{2, 0, 1})}});
 }
 
@@ -136,17 +136,17 @@ BOOST_FIXTURE_TEST_CASE(SimpleLetRec, Fixture) {
         create_instruction(AssignConstant{1, 0}),
         create_instruction(AssignConstant{2, 5}),
         create_instruction(
-            CallIndirect{3, 0, portable_index_array_from_vector({1, 2})})},
-       {create_instruction(Equal{3, 2, 1}),
+            BlockingCallIndirect{3, 0, portable_index_array_from_vector({1, 2})})},
+       {create_instruction(Equal{3, 1, 2}),
         create_instruction(
-            CreateLambda{4, 2, portable_index_array_from_vector({0, 2, 1})}),
-        create_instruction(If{3, 3, 4}), create_instruction(Assign{5, 1}),
+            CreateLambda{4, 2, portable_index_array_from_vector({0, 1, 2})}),
+        create_instruction(If{3, 3, 4}), create_instruction(Assign{5, 2}),
         create_instruction(
-            CallIndirect{6, 4, PortableMemPool::ArrayHandle<Index_t>()})},
+            BlockingCallIndirect{6, 4, PortableMemPool::ArrayHandle<Index_t>()})},
        {create_instruction(AssignConstant{3, 1}),
         create_instruction(Add{4, 3, 1}),
         create_instruction(
-            CallIndirect{5, 0, portable_index_array_from_vector({4, 2})})}});
+            BlockingCallIndirect{5, 0, portable_index_array_from_vector({4, 2})})}});
 }
 
 BOOST_FIXTURE_TEST_CASE(CheckBarrierInstructionGenerated, Fixture) {

--- a/Core/EvaluatorV2/tests/BlockGenerator.cpp
+++ b/Core/EvaluatorV2/tests/BlockGenerator.cpp
@@ -135,18 +135,18 @@ BOOST_FIXTURE_TEST_CASE(SimpleLetRec, Fixture) {
             CreateLambda{0, 1, portable_index_array_from_vector({0})}),
         create_instruction(AssignConstant{1, 0}),
         create_instruction(AssignConstant{2, 5}),
-        create_instruction(
-            BlockingCallIndirect{3, 0, portable_index_array_from_vector({1, 2})})},
+        create_instruction(BlockingCallIndirect{
+            3, 0, portable_index_array_from_vector({1, 2})})},
        {create_instruction(Equal{3, 1, 2}),
         create_instruction(
             CreateLambda{4, 2, portable_index_array_from_vector({0, 1, 2})}),
         create_instruction(If{3, 3, 4}), create_instruction(Assign{5, 2}),
-        create_instruction(
-            BlockingCallIndirect{6, 4, PortableMemPool::ArrayHandle<Index_t>()})},
+        create_instruction(BlockingCallIndirect{
+            6, 4, PortableMemPool::ArrayHandle<Index_t>()})},
        {create_instruction(AssignConstant{3, 1}),
         create_instruction(Add{4, 3, 1}),
-        create_instruction(
-            BlockingCallIndirect{5, 0, portable_index_array_from_vector({4, 2})})}});
+        create_instruction(BlockingCallIndirect{
+            5, 0, portable_index_array_from_vector({4, 2})})}});
 }
 
 BOOST_FIXTURE_TEST_CASE(CheckBarrierInstructionGenerated, Fixture) {

--- a/Core/EvaluatorV2/tests/CMakeLists.txt
+++ b/Core/EvaluatorV2/tests/CMakeLists.txt
@@ -22,3 +22,13 @@ endif()
 target_compile_definitions(IndirectCallHandlerTestExe PRIVATE "BOOST_TEST_DYN_LINK=1")
 target_link_libraries(IndirectCallHandlerTestExe EvaluatorV2 ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 add_test(NAME IndirectCallHandlerTest WORKING_DIRECTORY ${CMAKE_BINARY_DIR} COMMAND IndirectCallHandlerTestExe)
+
+add_executable(EvaluatorTestExe Evaluator.cpp)
+if (ENABLE_COMPUTE_CPP)
+  add_sycl_to_target(
+          TARGET "EvaluatorTestExe"
+          SOURCES Evaluator.cpp)
+endif()
+target_compile_definitions(EvaluatorTestExe PRIVATE "BOOST_TEST_DYN_LINK=1")
+target_link_libraries(EvaluatorTestExe EvaluatorV2 ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+add_test(NAME EvaluatorTest WORKING_DIRECTORY ${CMAKE_BINARY_DIR} COMMAND EvaluatorTestExe)

--- a/Core/EvaluatorV2/tests/Evaluator.cpp
+++ b/Core/EvaluatorV2/tests/Evaluator.cpp
@@ -1,0 +1,57 @@
+#define BOOST_TEST_MODULE EvaluatorTestModule
+#include "Core/EvaluatorV2/Evaluator.hpp"
+#include "Core/EvaluatorV2/CompileProgram.hpp"
+#include <boost/test/included/unit_test.hpp>
+
+namespace FunGPU::EvaluatorV2 {
+struct Fixture {
+  std::shared_ptr<PortableMemPool> mem_pool_data =
+      std::make_shared<PortableMemPool>();
+  cl::sycl::buffer<PortableMemPool> mem_pool_buffer{mem_pool_data,
+                                                    cl::sycl::range<1>(1)};
+  Evaluator evaluator{mem_pool_buffer};
+
+  void check_program_yields_result(const Float_t expected_val,
+                                   const std::string &program_path) {
+    const auto compiled_program =
+        compile_program(program_path, Evaluator::REGISTERS_PER_THREAD,
+                        Evaluator::THREADS_PER_BLOCK, mem_pool_buffer);
+    const auto result = evaluator.compute(compiled_program);
+    BOOST_CHECK(result.type == RuntimeValue::Type::FLOAT);
+    BOOST_CHECK_EQUAL(expected_val, result.data.float_val);
+  }
+};
+
+namespace {
+BOOST_FIXTURE_TEST_CASE(NoBindings, Fixture) {
+  check_program_yields_result(14, "./TestPrograms/NoBindings.fgpu");
+}
+
+BOOST_FIXTURE_TEST_CASE(ComplexBindings, Fixture) {
+  check_program_yields_result(13, "./TestPrograms/ComplexBindings.fgpu");
+}
+
+BOOST_FIXTURE_TEST_CASE(SimpleCall, Fixture) {
+  check_program_yields_result(42, "./TestPrograms/SimpleCall.fgpu");
+}
+
+BOOST_FIXTURE_TEST_CASE(SimpleLetRec, Fixture) {
+  check_program_yields_result(5, "./TestPrograms/SimpleLetRec.fgpu");
+}
+BOOST_FIXTURE_TEST_CASE(MultiLetRec, Fixture) {
+  check_program_yields_result(135, "./TestPrograms/MultiLetRec.fgpu");
+}
+BOOST_FIXTURE_TEST_CASE(ListExample, Fixture) {
+  check_program_yields_result(6, "./TestPrograms/ListExample.fgpu");
+}
+BOOST_FIXTURE_TEST_CASE(MultiList, Fixture) {
+  check_program_yields_result(3, "./TestPrograms/MultiList.fgpu");
+}
+BOOST_FIXTURE_TEST_CASE(MapExample, Fixture) {
+  check_program_yields_result(1, "./TestPrograms/MapExample.fgpu");
+}
+BOOST_FIXTURE_TEST_CASE(MergeSort, Fixture) {
+  check_program_yields_result(123456, "./TestPrograms/MergeSort.fgpu");
+}
+} // namespace
+} // namespace FunGPU::EvaluatorV2

--- a/Core/EvaluatorV2/tests/IndirectCallHandler.cpp
+++ b/Core/EvaluatorV2/tests/IndirectCallHandler.cpp
@@ -145,9 +145,8 @@ BOOST_FIXTURE_TEST_CASE(basic, BasicFixture) {
     const auto &target_data = first_block.target_data[0];
     BOOST_CHECK_EQUAL(1, target_data.thread);
     BOOST_CHECK_EQUAL(2, target_data.register_idx);
-    BOOST_CHECK(
-        caller_buf.get_access<cl::sycl::access::mode::read>()[0] ==
-        target_data.block);
+    BOOST_CHECK(caller_buf.get_access<cl::sycl::access::mode::read>()[0] ==
+                target_data.block);
   };
 
   if (mem_pool_acc[0].derefHandle(exec_group.block_descs)[0].instructions ==

--- a/Core/EvaluatorV2/tests/IndirectCallHandler.cpp
+++ b/Core/EvaluatorV2/tests/IndirectCallHandler.cpp
@@ -133,7 +133,7 @@ BOOST_FIXTURE_TEST_CASE(basic, BasicFixture) {
     const std::array<RuntimeValue, 3> expected_captures_and_arg{
         RuntimeValue(2), RuntimeValue(3), RuntimeValue(42)};
     for (Index_t i = 0; i < expected_captures_and_arg.size(); ++i) {
-      const auto actual_val = first_block.registers[block_idx][i];
+      const auto actual_val = first_block.registers[0][i];
       const auto expected_val = expected_captures_and_arg[i];
       BOOST_CHECK_EQUAL(static_cast<int>(expected_val.type),
                         static_cast<int>(actual_val.type));
@@ -142,11 +142,11 @@ BOOST_FIXTURE_TEST_CASE(basic, BasicFixture) {
     BOOST_CHECK(block_meta.instructions ==
                 mem_pool_acc[0].derefHandle(program)[0].instructions);
     BOOST_CHECK_EQUAL(1, block_meta.num_threads);
-    const auto &target_data = first_block.target_data[block_idx];
+    const auto &target_data = first_block.target_data[0];
     BOOST_CHECK_EQUAL(1, target_data.thread);
     BOOST_CHECK_EQUAL(2, target_data.register_idx);
     BOOST_CHECK(
-        caller_buf.get_access<cl::sycl::access::mode::read>()[block_idx] ==
+        caller_buf.get_access<cl::sycl::access::mode::read>()[0] ==
         target_data.block);
   };
 

--- a/Core/EvaluatorV2/tests/RuntimeBlock.cpp
+++ b/Core/EvaluatorV2/tests/RuntimeBlock.cpp
@@ -110,13 +110,13 @@ struct Fixture {
           mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>();
       const auto *lambdas = mem_pool_acc[0].derefHandle(no_bindings_program);
       const auto block_handle =
-          mem_pool_acc[0].Alloc<RuntimeBlockType>(lambdas[0].instructions);
+          mem_pool_acc[0].Alloc<RuntimeBlockType>(lambdas[0].instructions, THREADS_PER_BLOCK);
       const auto block_metadata_array =
           mem_pool_acc[0].AllocArray<RuntimeBlockType::BlockMetadata>(1);
       auto *block_meta_array_data =
           mem_pool_acc[0].derefHandle(block_metadata_array);
       block_meta_array_data[0] = RuntimeBlockType::BlockMetadata(
-          block_handle, lambdas[0].instructions);
+          block_handle, lambdas[0].instructions, THREADS_PER_BLOCK);
       return RuntimeBlockType::BlockExecGroup(
           block_metadata_array, lambdas[0].instructions.GetCount());
     }();
@@ -142,11 +142,11 @@ struct Fixture {
         BOOST_REQUIRE_EQUAL(1, no_bindings_program.GetCount());
         const auto *lambdas = mem_pool_acc[0].derefHandle(no_bindings_program);
         const auto block_handle =
-            mem_pool_acc[0].Alloc<RuntimeBlockType>(lambdas[0].instructions);
+            mem_pool_acc[0].Alloc<RuntimeBlockType>(lambdas[0].instructions, THREADS_PER_BLOCK);
         BOOST_REQUIRE(block_handle !=
                       PortableMemPool::Handle<RuntimeBlockType>());
         block_metadata_array_data[i++] = RuntimeBlockType::BlockMetadata(
-            block_handle, lambdas[0].instructions);
+            block_handle, lambdas[0].instructions, THREADS_PER_BLOCK);
         max_instructions_per_block = std::max(
             max_instructions_per_block, lambdas[0].instructions.GetCount());
       }

--- a/Core/EvaluatorV2/tests/RuntimeBlock.cpp
+++ b/Core/EvaluatorV2/tests/RuntimeBlock.cpp
@@ -109,8 +109,8 @@ struct Fixture {
       auto mem_pool_acc =
           mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>();
       const auto *lambdas = mem_pool_acc[0].derefHandle(no_bindings_program);
-      const auto block_handle =
-          mem_pool_acc[0].Alloc<RuntimeBlockType>(lambdas[0].instructions, THREADS_PER_BLOCK);
+      const auto block_handle = mem_pool_acc[0].Alloc<RuntimeBlockType>(
+          lambdas[0].instructions, THREADS_PER_BLOCK);
       const auto block_metadata_array =
           mem_pool_acc[0].AllocArray<RuntimeBlockType::BlockMetadata>(1);
       auto *block_meta_array_data =
@@ -141,8 +141,8 @@ struct Fixture {
         const auto no_bindings_program = generate_program(prog);
         BOOST_REQUIRE_EQUAL(1, no_bindings_program.GetCount());
         const auto *lambdas = mem_pool_acc[0].derefHandle(no_bindings_program);
-        const auto block_handle =
-            mem_pool_acc[0].Alloc<RuntimeBlockType>(lambdas[0].instructions, THREADS_PER_BLOCK);
+        const auto block_handle = mem_pool_acc[0].Alloc<RuntimeBlockType>(
+            lambdas[0].instructions, THREADS_PER_BLOCK);
         BOOST_REQUIRE(block_handle !=
                       PortableMemPool::Handle<RuntimeBlockType>());
         block_metadata_array_data[i++] = RuntimeBlockType::BlockMetadata(

--- a/TestPrograms/NumericIntegration.fgpu
+++ b/TestPrograms/NumericIntegration.fgpu
@@ -16,4 +16,4 @@
                                                                         (+ accum (integrate-between f a b max-width))
                                                                         (integrate-by-blocks f cur-upper-bound b max-width block-size
                                                                                              (+ accum  (integrate-between f a cur-upper-bound max-width))))))))
-                                     (integrate-by-blocks hard-function 2 2048 0.01 80 0)))
+                                     (integrate-by-blocks hard-function 2 2048 1 128 0)))


### PR DESCRIPTION
Finish implementing the more efficient evaluator variant. Outperforms Racket implementation for even relatively small numeric integration launches. TODO start freeing memory in more places, investigate adding garbage collector for lambda values. Everything else can be deallocated manually.