### PR TITLE
Update to support building with AdaptiveCpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4.3)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2a")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++23")
 
 include_directories(${CMAKE_SOURCE_DIR})
 
@@ -10,12 +10,12 @@ enable_testing()
 set(ENABLE_COMPUTE_CPP OFF)
 
 if(ENABLE_COMPUTE_CPP)
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
-include(FindComputeCpp)
-include_directories(SYSTEM "${ComputeCpp_INCLUDE_DIRS}")
-include_directories(SYSTEM "${OpenCL_INCLUDE_DIR}")
+	list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
+	include(FindComputeCpp)
+	include_directories(SYSTEM "${ComputeCpp_INCLUDE_DIRS}")
+	include_directories(SYSTEM "${OpenCL_INCLUDE_DIR}")
 else()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I /usr/local/include/hipSYCL/")
+	find_package(AdaptiveCpp REQUIRED)
 endif()
 
 find_package(Boost 1.58 REQUIRED COMPONENTS unit_test_framework)
@@ -29,7 +29,7 @@ add_subdirectory(IntegrationTests)
 target_link_libraries(FunGPU FunGPUEvaluator)
 
 file(GLOB_RECURSE ALL_SOURCE_FILES Core/*.cpp Core/*.h Core/*.hpp main.cpp)
-find_program (CLANGFORMAT_CMD clang-format "/usr/lib/llvm-9/bin/")
+find_program (CLANGFORMAT_CMD clang-format "/usr/lib/llvm-18/bin/")
 
 add_custom_target(clangformat
     COMMAND ${CLANGFORMAT_CMD}

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -1,6 +1,8 @@
 FILE(GLOB SOURCE_LIST)
 
 add_library(FunGPUCore Compiler.cpp Parser.cpp SExpr.cpp BlockPrep.cpp CollectAllASTNodes.cpp)
+add_sycl_to_target(TARGET FunGPUCore)
+
 add_library(FunGPUEvaluator CPUEvaluator.cpp)
 target_link_libraries(FunGPUEvaluator FunGPUCore)
 

--- a/Core/EvaluatorV2/CMakeLists.txt
+++ b/Core/EvaluatorV2/CMakeLists.txt
@@ -1,12 +1,11 @@
 add_library(EvaluatorV2 BlockGenerator.cpp Instruction.cpp Lambda.cpp Program.cpp CompileProgram.cpp Evaluator.cpp)
-target_link_libraries(EvaluatorV2 FunGPUCore)
+add_sycl_to_target(
+  TARGET
+    EvaluatorV2
+)
+target_link_libraries(EvaluatorV2 PUBLIC FunGPUCore)
 
 add_executable(FunGPUV2 FunGPUV2.cpp)
-if (ENABLE_COMPUTE_CPP)
-  add_sycl_to_target(
-          TARGET "FunGPUV2"
-          SOURCES FunGPUV2.cpp)
-endif()
 target_link_libraries(FunGPUV2 EvaluatorV2 ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 
 add_subdirectory(tests)

--- a/Core/EvaluatorV2/Evaluator.hpp
+++ b/Core/EvaluatorV2/Evaluator.hpp
@@ -6,7 +6,7 @@
 #include "Core/EvaluatorV2/RuntimeValue.h"
 #include "Core/PortableMemPool.hpp"
 #include "Core/sycl.hpp"
-#include "sycl/queue.hpp"
+#include <CL/sycl.hpp>
 #include <optional>
 
 namespace FunGPU::EvaluatorV2 {

--- a/Core/EvaluatorV2/Instruction.h
+++ b/Core/EvaluatorV2/Instruction.h
@@ -119,9 +119,8 @@ using GreaterThan = BinaryOp<InstructionType::GREATER_THAN>;
 using Remainder = BinaryOp<InstructionType::REMAINDER>;
 using Expt = BinaryOp<InstructionType::EXPT>;
 
-template <typename T> concept HasTargetRegister = requires(T x) {
-  x.target_register;
-};
+template <typename T>
+concept HasTargetRegister = requires(T x) { x.target_register; };
 
 struct Instruction {
   std::string print(PortableMemPool::HostAccessor_t mem_pool_acc) const;

--- a/Core/EvaluatorV2/tests/BlockGenerator.cpp
+++ b/Core/EvaluatorV2/tests/BlockGenerator.cpp
@@ -6,7 +6,7 @@
 #include "Core/EvaluatorV2/CompileProgram.hpp"
 #include "Core/Parser.hpp"
 #include "Core/Visitor.hpp"
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <stdexcept>
 
 namespace FunGPU::EvaluatorV2 {

--- a/Core/EvaluatorV2/tests/Evaluator.cpp
+++ b/Core/EvaluatorV2/tests/Evaluator.cpp
@@ -1,7 +1,7 @@
 #define BOOST_TEST_MODULE EvaluatorTestModule
 #include "Core/EvaluatorV2/Evaluator.hpp"
 #include "Core/EvaluatorV2/CompileProgram.hpp"
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 namespace FunGPU::EvaluatorV2 {
 struct Fixture {

--- a/Core/EvaluatorV2/tests/IndirectCallHandler.cpp
+++ b/Core/EvaluatorV2/tests/IndirectCallHandler.cpp
@@ -4,9 +4,7 @@
 #include "Core/EvaluatorV2/RuntimeBlock.hpp"
 #include "Core/EvaluatorV2/RuntimeValue.h"
 #include "Core/PortableMemPool.hpp"
-#include "sycl/handler.hpp"
-#include "sycl/libkernel/item.hpp"
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <unordered_set>
 
 namespace FunGPU::EvaluatorV2 {

--- a/Core/EvaluatorV2/tests/RuntimeBlock.cpp
+++ b/Core/EvaluatorV2/tests/RuntimeBlock.cpp
@@ -6,8 +6,8 @@
 #include "Core/EvaluatorV2/CompileProgram.hpp"
 #include "Core/Parser.hpp"
 #include "Core/Visitor.hpp"
-#include <boost/test/included/unit_test.hpp>
 #include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
 #include <cmath>
 #include <stdexcept>
 

--- a/Core/GarbageCollector.hpp
+++ b/Core/GarbageCollector.hpp
@@ -16,7 +16,7 @@ public:
 
   template <class... Args_t>
   Error AllocManaged(const PortableMemPool::DeviceAccessor_t &memPoolAcc,
-                     PortableMemPool::Handle<T> &result, Args_t &&... args) {
+                     PortableMemPool::Handle<T> &result, Args_t &&...args) {
     cl::sycl::atomic<Index_t> allocCount(
         (cl::sycl::multi_ptr<Index_t,
                              cl::sycl::access::address_space::global_space>(

--- a/Core/Parser.hpp
+++ b/Core/Parser.hpp
@@ -14,7 +14,7 @@ public:
 private:
   struct ParsedExpr {
     virtual void DebugPrint() = 0;
-    virtual ~ParsedExpr(){};
+    virtual ~ParsedExpr() {};
   };
 
   struct ParenthesizedExpr : public ParsedExpr {

--- a/Core/PortableMemPool.hpp
+++ b/Core/PortableMemPool.hpp
@@ -129,7 +129,7 @@ public:
     // Handle<T> m_handle;
   };
 
-  template <class T, class... Args_t> Handle<T> Alloc(const Args_t &... args) {
+  template <class T, class... Args_t> Handle<T> Alloc(const Args_t &...args) {
     const auto handle =
         AllocImpl<T>(m_smallBin, m_mediumBin, m_largeBin, m_extraLargeBin);
     if (handle == Handle<T>()) {
@@ -277,7 +277,7 @@ private:
             Index_t... allocSizes, Index_t... totalSizes>
   decltype(auto) WithArena(Pred &&pred, CB &&cb,
                            Arena<allocSize, totalSize> &arena,
-                           Arena<allocSizes, totalSizes> &... arenas) {
+                           Arena<allocSizes, totalSizes> &...arenas) {
     if (pred(arena)) {
       return cb(arena);
     }
@@ -311,7 +311,7 @@ private:
   };
 
   template <class T, Index_t... allocSizes, Index_t... totalSizes>
-  Handle<T> AllocImpl(Arena<allocSizes, totalSizes> &... arenas) {
+  Handle<T> AllocImpl(Arena<allocSizes, totalSizes> &...arenas) {
     return WithArena<T>(AllocPred<T>(), AllocHandler<T>(*this), arenas...);
   }
 
@@ -357,7 +357,7 @@ private:
 
   template <class T, Index_t... allocSizes, Index_t... totalSizes>
   ArrayHandle<T> AllocArrayImpl(const Index_t arraySize, const T &initialValue,
-                                Arena<allocSizes, totalSizes> &... arenas) {
+                                Arena<allocSizes, totalSizes> &...arenas) {
     return WithArena<T>(AllocArrayPred<T>(arraySize),
                         AllocArrayHandler<T>(arraySize, initialValue, *this),
                         arenas...);
@@ -396,7 +396,7 @@ private:
 
   template <class T, Index_t... allocSizes, Index_t... totalSizes>
   void DeallocImpl(const Handle<T> &handle,
-                   Arena<allocSizes, totalSizes> &... arenas) {
+                   Arena<allocSizes, totalSizes> &...arenas) {
     WithArena<T>(MatchArenaOffset<T>(*this, handle.GetDistFromMemPoolBase()),
                  DeallocHandler<T>(handle, *this), arenas...);
   }
@@ -424,7 +424,7 @@ private:
 
   template <class T, Index_t... allocSizes, Index_t... totalSizes>
   void DeallocArrayImpl(const ArrayHandle<T> &arrayHandle,
-                        Arena<allocSizes, totalSizes> &... arenas) {
+                        Arena<allocSizes, totalSizes> &...arenas) {
     WithArena<T>(MatchArenaOffset<T>(
                      *this, arrayHandle.m_handle.GetDistFromMemPoolBase()),
                  DeallocArrayHandler<T>(arrayHandle, *this), arenas...);
@@ -434,7 +434,7 @@ private:
             Index_t... totalSizes>
   Index_t
   GetTotalAllocationCountImpl(Arena<allocSize, totalSize> &arena,
-                              Arena<allocSizes, totalSizes> &... arenas) {
+                              Arena<allocSizes, totalSizes> &...arenas) {
     Index_t totalAllocCount = 0;
 
     cl::sycl::atomic<Index_t> totalAllocations(
@@ -459,7 +459,7 @@ private:
   template <class T, Index_t allocSize, Index_t totalSize,
             Index_t... allocSizes, Index_t... totalSizes>
   Index_t GetNumFreeImpl(Arena<allocSize, totalSize> &arena,
-                         Arena<allocSizes, totalSizes> &... arenas) {
+                         Arena<allocSizes, totalSizes> &...arenas) {
     if (allocSize >= sizeof(T)) {
       cl::sycl::atomic<Index_t> totalAllocations(
           (cl::sycl::multi_ptr<Index_t,

--- a/Core/Visitor.hpp
+++ b/Core/Visitor.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 namespace FunGPU {
-template <class... Ts> struct Visitor : Ts... { using Ts::operator()...; };
+template <class... Ts> struct Visitor : Ts... {
+  using Ts::operator()...;
+};
 template <class... Ts> Visitor(Ts...) -> Visitor<Ts...>;
 } // namespace FunGPU

--- a/IntegrationTests/IntegrationTests.cpp
+++ b/IntegrationTests/IntegrationTests.cpp
@@ -3,7 +3,7 @@
 //
 
 #define BOOST_TEST_MODULE IntegrationTestsModule
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 // windows weirdness
 #undef max

--- a/README.md
+++ b/README.md
@@ -129,12 +129,11 @@ Numeric integration (https://github.com/BenjaminTrapani/FunGPU/blob/master/TestP
 The current implementation has two versions: an initial interpreter (binary FunGPU) that evaluates the AST directly. Warp divergence is high and execution efficiency is low, but it contains a garbage collector and is very stable. The more recent and fastest version (./Core/EvaluatorV2/FunGPUV2) uses the compilation pipeline above and outperforms the racket implementation on all non-trivial programs (performance gains increase as the number of program subtrees increases, think embarrassingly parallel problems with divide and conquer solutions). The evaluator at ./Core/EvaluatorV2/FunGPUV2 does not have a garbage collector yet, which is required to correctly deallocate lambda captures. Lambda captures are leaked in that implementation. The remaining work consists of adding a garbage collector for the V2 evaluator, improving GPU utilization by reducing shared memory requirements and adding optimization steps to the compilation pipeline.
 
 ## Building ##
-1. Install hipSYCL by following the instructions at https://github.com/illuhad/hipSYCL
+1. Install AdaptiveCpp by following the instructions at https://github.com/AdaptiveCpp/AdaptiveCpp/blob/develop/doc/installing.md
 2. mkdir build
 3. cd build
-4. export HIPSYCL_GPU_ARCH={gpu architecture of choice. sm_61 tested for nvidia gpus}
-5. cmake -DCMAKE_CXX_COMPILER=syclcc-clang -DCMAKE_BUILD_TYPE=Release -G Ninja ../
-6. ninja all
+3. cmake -DCMAKE_CXX_COMPILER=acpp -DCMAKE_BUILD_TYPE=Release ../
+6. make
 
 The built binary can be run as ./Core/EvaluatorV2/FunGPUV2 ../TestPrograms/MergeSort.fgpu
 

--- a/TestPrograms/NumericIntegrationV2.fgpu
+++ b/TestPrograms/NumericIntegrationV2.fgpu
@@ -19,4 +19,4 @@
                                (if (> cur-width block-width)
                                    (perform-recursion self integrate-with-accum-f num-integrate-f f a b midpoint max-width block-width)
                                    (integrate-with-accum-f integrate-with-accum-f num-integrate-f f a b max-width zero))))))
-      (integrate-between integrate-between integrate-with-accum num-integrate hard-function 0 ( * 2 4096) 0.001 (* 2 0.25)))
+      (integrate-between integrate-between integrate-with-accum num-integrate hard-function 0 ( * 7 4096) 0.001 (* 7 0.25)))


### PR DESCRIPTION
The test program NumericIntegrationV2.fpgu outperforms the racket implementation by a factor of 2 after the initial JIT as of AdaptiveCpp at latest develop. The test targeted an RTX 4090 with cuda 12.4.