### PR TITLE
Update includes for clangd support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.vs
+.vscode
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ if(ENABLE_COMPUTE_CPP)
 	include_directories(SYSTEM "${OpenCL_INCLUDE_DIR}")
 else()
 	find_package(AdaptiveCpp REQUIRED)
+	# To ensure that the system include is appended to the compile_commands.json
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -isystem /usr/local/include/AdaptiveCpp/")
 endif()
 
 find_package(Boost 1.58 REQUIRED COMPONENTS unit_test_framework)

--- a/Core/CPUEvaluator.hpp
+++ b/Core/CPUEvaluator.hpp
@@ -3,7 +3,7 @@
 #include "Core/GarbageCollector.hpp"
 #include "Core/PortableMemPool.hpp"
 #include "Core/RuntimeBlock.hpp"
-#include "Core/sycl.hpp"
+#include <CL/sycl.hpp>
 #include <array>
 #include <memory>
 

--- a/Core/Compiler.hpp
+++ b/Core/Compiler.hpp
@@ -4,7 +4,7 @@
 #include "Core/PortableMemPool.hpp"
 #include "Core/SExpr.hpp"
 #include "Core/Types.hpp"
-#include "Core/sycl.hpp"
+#include <CL/sycl.hpp>
 
 #include <list>
 #include <memory>

--- a/Core/EvaluatorV2/Evaluator.hpp
+++ b/Core/EvaluatorV2/Evaluator.hpp
@@ -5,7 +5,6 @@
 #include "Core/EvaluatorV2/RuntimeBlock.hpp"
 #include "Core/EvaluatorV2/RuntimeValue.h"
 #include "Core/PortableMemPool.hpp"
-#include "Core/sycl.hpp"
 #include <CL/sycl.hpp>
 #include <optional>
 

--- a/Core/GarbageCollector.hpp
+++ b/Core/GarbageCollector.hpp
@@ -6,7 +6,7 @@
 
 #include "Core/Error.hpp"
 #include "Core/PortableMemPool.hpp"
-#include "Core/sycl.hpp"
+#include <CL/sycl.hpp>
 
 namespace FunGPU {
 template <class T, Index_t maxManagedAllocationsCount> class GarbageCollector {

--- a/Core/List.hpp
+++ b/Core/List.hpp
@@ -1,7 +1,7 @@
 #include "Core/Error.hpp"
 #include "Core/PortableMemPool.hpp"
 #include "Core/Types.hpp"
-#include "Core/sycl.hpp"
+#include <CL/sycl.hpp>
 #include <memory>
 
 namespace FunGPU {

--- a/Core/PortableMemPool.hpp
+++ b/Core/PortableMemPool.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Core/Types.hpp"
-#include "Core/sycl.hpp"
+#include <CL/sycl.hpp>
 #include <limits>
 #include <memory>
 #include <type_traits>

--- a/Core/RuntimeBlock.hpp
+++ b/Core/RuntimeBlock.hpp
@@ -4,7 +4,7 @@
 #include "Core/List.hpp"
 #include "Core/PortableMemPool.hpp"
 #include "Core/Types.hpp"
-#include "Core/sycl.hpp"
+#include <CL/sycl.hpp>
 #include <atomic>
 
 namespace FunGPU {


### PR DESCRIPTION
Explicitly specify the system include path for adaptive cpp to work around a cmake issue omitting additional system includes specified with target_include_directories. Update gitignore with ignores for the build directory and vscode configuration.