### PR TITLE
BlockPrep: remove branches from bound expressions

### DIFF
--- a/Core/EvaluatorV2/tests/Evaluator.cpp
+++ b/Core/EvaluatorV2/tests/Evaluator.cpp
@@ -52,5 +52,8 @@ BOOST_FIXTURE_TEST_CASE(MapExample, Fixture) {
 BOOST_FIXTURE_TEST_CASE(MergeSort, Fixture) {
   check_program_yields_result(123456, "./TestPrograms/MergeSort.fgpu");
 }
+BOOST_FIXTURE_TEST_CASE(BranchInBinding, Fixture) {
+  check_program_yields_result(8, "./TestPrograms/BranchInBinding.fgpu");
+}
 } // namespace
 } // namespace FunGPU::EvaluatorV2

--- a/TestPrograms/BranchInBinding.fgpu
+++ b/TestPrograms/BranchInBinding.fgpu
@@ -1,0 +1,3 @@
+(let ((x 1) (y 2))
+    (let ((branch-result (if (= x 2) 3 4)))
+        (* branch-result 2)))


### PR DESCRIPTION
BlockPrep: remove branches from bound expressions

The block generation step requires that all branches are located in the
tail position in each lambda and that each branch is a single
instruction. If a branch appears in the right hand side of a bound
expression, lift the branch above the current bind expression.
Conditionally bind the expressions for the true and false branch,
continuing with the current binding in the body.

For example:
```
( let
  (
    ( x  1 )
    ( y  2 ))
  ( let
    (
      ( branch-result
        ( if
          ( =  x  2 ) 3  4 )))
    ( *  branch-result  2 )))
```
becomes
```
( let
  (
    ( x  1 )
    ( y  2 ))
  ( if ( = x 2 )
    ( let (( branch-result 3 )) ( * branch-result 2))
    ( let (( branch-result 4 )) ( * branch-result 2))))
```

The block preparation pass for branches restructures the generated
branch to ensure that it is in the faill position for the current
expression and that both branches are a single instruction.