### PR TITLE
Evaluator: use finer grained barriers

### DIFF
--- a/Core/EvaluatorV2/IndirectCallHandler.hpp
+++ b/Core/EvaluatorV2/IndirectCallHandler.hpp
@@ -437,7 +437,12 @@ IndirectCallHandler<RuntimeBlockType, MaxNumIndirectCalls,
           cl::sycl::atomic<Index_t> copy_begin_atomic(copy_begin_atomic_acc[0]);
           const auto source_block_descs =
               block_exec_group_per_lambda_acc[itm.get_id(0)].block_descs;
-          const auto source_data =
+          if (source_block_descs ==
+              PortableMemPool::ArrayHandle<
+                  typename RuntimeBlockType::BlockMetadata>()) {
+            return;
+          }
+          const auto *source_data =
               mem_pool_write[0].derefHandle(source_block_descs);
           if (itm.get_id(1) < source_block_descs.GetCount()) {
             target_block_descs[copy_begin_atomic.fetch_add(1)] =

--- a/Core/EvaluatorV2/tests/RuntimeBlock.cpp
+++ b/Core/EvaluatorV2/tests/RuntimeBlock.cpp
@@ -71,7 +71,7 @@ struct Fixture {
                  idx += THREADS_PER_BLOCK) {
               instructions_for_block[idx] = instructions_global_data[idx];
             }
-            itm.barrier();
+            itm.barrier(cl::sycl::access::fence_space::local_space);
             RuntimeBlockType::Status status = local_block[0].evaluate(
                 block_idx, thread_idx, mem_pool_write, local_instructions,
                 block_meta.instructions.GetCount(), [](auto &&...) {},


### PR DESCRIPTION
Only pending writes to local memory must be flushed prior to continuing. Update all existing barriers to reflect this constraint.