### PR TITLE
RuntimeBlock: fix shared memory race condition

### DIFF
--- a/Core/EvaluatorV2/tests/RuntimeBlock.cpp
+++ b/Core/EvaluatorV2/tests/RuntimeBlock.cpp
@@ -73,7 +73,7 @@ struct Fixture {
             }
             itm.barrier(cl::sycl::access::fence_space::local_space);
             RuntimeBlockType::Status status = local_block[0].evaluate(
-                block_idx, thread_idx, mem_pool_write, local_instructions,
+                block_idx, thread_idx, itm, mem_pool_write, local_instructions,
                 block_meta.instructions.GetCount(), [](auto &&...) {},
                 [](const auto) {});
             if (status == RuntimeBlockType::Status::COMPLETE) {


### PR DESCRIPTION
The RuntimeBlock member `cur_cycle` was located in shared memory and incremented across all threads in each group. This worked as expected on nvidia GPUs because all threads in a warp execute in lock step, ensuring that the incremented integer was consistent. Store the instruction index in thread-local memory and commit back to local memory at the end of each evaluation sequence.