### PR TITLE
Branch in binding rewrite rule: reduce generated code size

### DIFF
--- a/Core/EvaluatorV2/tests/Evaluator.cpp
+++ b/Core/EvaluatorV2/tests/Evaluator.cpp
@@ -53,7 +53,7 @@ BOOST_FIXTURE_TEST_CASE(MergeSort, Fixture) {
   check_program_yields_result(123456, "./TestPrograms/MergeSort.fgpu");
 }
 BOOST_FIXTURE_TEST_CASE(BranchInBinding, Fixture) {
-  check_program_yields_result(8, "./TestPrograms/BranchInBinding.fgpu");
+  check_program_yields_result(130, "./TestPrograms/BranchInBinding.fgpu");
 }
 } // namespace
 } // namespace FunGPU::EvaluatorV2

--- a/TestPrograms/BranchInBinding.fgpu
+++ b/TestPrograms/BranchInBinding.fgpu
@@ -1,3 +1,5 @@
 (let ((x 1) (y 2))
     (let ((branch-result (if (= x 2) 3 4)))
-        (* branch-result 2)))
+        (let ((a-val 10) (inner-branch-result (if (= branch-result 4) (* branch-result 2) (* branch-result 4)))
+            (b-val 15))
+            (+ a-val (* inner-branch-result b-val)))))


### PR DESCRIPTION
Instead of duplicating the logic in the bound expression body across both branches, move the body of the let expression to a lambda that is invoked with the branch-dependent value as an argument. Doing so also ensures that the AST does not contain cycles.