### PR TITLE
Remove dynamic memory allocations from block evaluation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,4 +36,5 @@ find_program (CLANGFORMAT_CMD clang-format "/usr/lib/llvm-18/bin/")
 add_custom_target(clangformat
     COMMAND ${CLANGFORMAT_CMD}
     -i
-    ${ALL_SOURCE_FILES})
+    ${ALL_SOURCE_FILES}
+	-style=file)

--- a/Core/Compiler.cpp
+++ b/Core/Compiler.cpp
@@ -473,7 +473,7 @@ void Compiler::DeallocateAST(const ASTNodeHandle &rootOfASTHandle,
     break;
   }
   default:
-    throw CompileException("Unexpected AST node type during debug print");
+    throw CompileException("Unexpected AST node type during deallocate");
   }
 }
 

--- a/Core/Concepts.h
+++ b/Core/Concepts.h
@@ -1,0 +1,6 @@
+#include <concepts>
+
+namespace FunGPU {
+template <typename Type, typename... PossibleTypes>
+concept OneOf = (std::is_same_v<Type, PossibleTypes> || ...);
+}

--- a/Core/EvaluatorV2/BlockGenerator.cpp
+++ b/Core/EvaluatorV2/BlockGenerator.cpp
@@ -579,7 +579,7 @@ Lambda BlockGenerator::construct_block(
   for (Index_t i = 0; i < instructions_handle.GetCount(); ++i) {
     instructions_data[i] = result_instructions[i];
   }
-  return Lambda(instructions_handle);
+  return Lambda(instructions_handle, mem_pool_acc);
 }
 
 Program BlockGenerator::construct_blocks(const Compiler::ASTNodeHandle root) {

--- a/Core/EvaluatorV2/CompileProgram.cpp
+++ b/Core/EvaluatorV2/CompileProgram.cpp
@@ -31,6 +31,7 @@ Program compile_program(const std::string &path,
   std::cout << std::endl << std::endl;
 
   const auto program = block_generator.construct_blocks(compiled_result);
+  compiler.DeallocateAST(compiled_result);
   auto mem_pool_acc =
       mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>();
   std::cout << "Printed program: " << std::endl;

--- a/Core/EvaluatorV2/Instruction.h
+++ b/Core/EvaluatorV2/Instruction.h
@@ -124,8 +124,8 @@ concept HasTargetRegister = requires(T x) { x.target_register; };
 
 struct Instruction {
   std::string print(PortableMemPool::HostAccessor_t mem_pool_acc) const;
-
   bool equals(const Instruction &, PortableMemPool::HostAccessor_t &) const;
+  void deallocate(PortableMemPool::HostAccessor_t);
 
   Instruction() = default;
   Instruction(const InstructionType type) : type(type) {}

--- a/Core/EvaluatorV2/Lambda.cpp
+++ b/Core/EvaluatorV2/Lambda.cpp
@@ -1,7 +1,65 @@
 #include "Core/EvaluatorV2/Lambda.hpp"
+#include "Core/PortableMemPool.hpp"
+#include "Core/Visitor.hpp"
 #include <sstream>
 
 namespace FunGPU::EvaluatorV2 {
+namespace {
+Lambda::InstructionProperties derive_instruction_properties(
+    const PortableMemPool::ArrayHandle<Instruction> &instructions,
+    PortableMemPool::HostAccessor_t &mem_pool_acc) {
+  Lambda::InstructionProperties result;
+  const auto *instruction_data = mem_pool_acc[0].derefHandle(instructions);
+  std::vector<Index_t> num_runtime_values_per_op;
+  for (Index_t i = 0; i < instructions.GetCount(); ++i) {
+    const auto &instruction = instruction_data[i];
+    visit(instruction,
+          Visitor{
+              [&](const CallIndirect &call_indirect) {
+                num_runtime_values_per_op.emplace_back(
+                    call_indirect.arg_indices.unpack().GetCount());
+                ++result.total_num_indirect_calls;
+              },
+              [&](const BlockingCallIndirect &blocking_call_indirect) {
+                num_runtime_values_per_op.emplace_back(
+                    blocking_call_indirect.arg_indices.unpack().GetCount());
+                ++result.total_num_indirect_calls;
+              },
+              [&](const CreateLambda &create_lambda) {
+                num_runtime_values_per_op.emplace_back(
+                    create_lambda.captured_indices.unpack().GetCount());
+              },
+              [](const auto &) {},
+          },
+          [](const auto &) {});
+  }
+  result.num_runtime_values_per_op =
+      mem_pool_acc[0].AllocArray<Index_t>(num_runtime_values_per_op.size());
+  auto *num_runtime_values_per_op_data =
+      mem_pool_acc[0].derefHandle(result.num_runtime_values_per_op);
+  for (Index_t i = 0; i < num_runtime_values_per_op.size(); ++i) {
+    num_runtime_values_per_op_data[i] = num_runtime_values_per_op[i];
+  }
+  return result;
+}
+} // namespace
+
+Lambda::Lambda(const PortableMemPool::ArrayHandle<Instruction> &instructions,
+               PortableMemPool::HostAccessor_t &mem_pool_acc)
+    : instructions(instructions),
+      instruction_properties(
+          derive_instruction_properties(instructions, mem_pool_acc)) {}
+
+void Lambda::deallocate(PortableMemPool::HostAccessor_t mem_pool_acc) {
+  auto *instruction_data = mem_pool_acc[0].derefHandle(instructions);
+  for (Index_t i = 0; i < instructions.GetCount(); ++i) {
+    instruction_data[i].deallocate(mem_pool_acc);
+  }
+  mem_pool_acc[0].DeallocArray(instructions);
+  mem_pool_acc[0].DeallocArray(
+      instruction_properties.num_runtime_values_per_op);
+}
+
 std::string Lambda::print(PortableMemPool::HostAccessor_t mem_pool_acc) const {
   std::stringstream result;
   const auto *instruction_data = mem_pool_acc[0].derefHandle(instructions);

--- a/Core/EvaluatorV2/Lambda.hpp
+++ b/Core/EvaluatorV2/Lambda.hpp
@@ -2,15 +2,23 @@
 
 #include "Core/EvaluatorV2/Instruction.h"
 #include "Core/PortableMemPool.hpp"
+#include "Core/Types.hpp"
 #include <string>
 
 namespace FunGPU::EvaluatorV2 {
 struct Lambda {
+  struct InstructionProperties {
+    Index_t total_num_indirect_calls;
+    PortableMemPool::ArrayHandle<Index_t> num_runtime_values_per_op;
+  };
+
   Lambda() = default;
-  explicit Lambda(const PortableMemPool::ArrayHandle<Instruction> &instructions)
-      : instructions(instructions) {}
+  explicit Lambda(const PortableMemPool::ArrayHandle<Instruction> &instructions,
+                  PortableMemPool::HostAccessor_t &mem_pool_acc);
   std::string print(PortableMemPool::HostAccessor_t) const;
+  void deallocate(PortableMemPool::HostAccessor_t);
 
   PortableMemPool::ArrayHandle<Instruction> instructions;
+  InstructionProperties instruction_properties;
 };
 } // namespace FunGPU::EvaluatorV2

--- a/Core/EvaluatorV2/Program.cpp
+++ b/Core/EvaluatorV2/Program.cpp
@@ -12,4 +12,14 @@ std::string print(const Program &program,
   }
   return result.str();
 }
+
+void deallocate_program(const Program &program,
+                        PortableMemPool::HostAccessor_t mem_pool_acc) {
+  auto *lambdas = mem_pool_acc[0].derefHandle(program);
+  for (Index_t i = 0; i < program.GetCount(); ++i) {
+    auto &lambda = lambdas[i];
+    lambda.deallocate(mem_pool_acc);
+  }
+  mem_pool_acc[0].DeallocArray(program);
+}
 } // namespace FunGPU::EvaluatorV2

--- a/Core/EvaluatorV2/Program.hpp
+++ b/Core/EvaluatorV2/Program.hpp
@@ -7,4 +7,5 @@ namespace FunGPU::EvaluatorV2 {
 using Program = PortableMemPool::ArrayHandle<Lambda>;
 
 std::string print(const Program &, PortableMemPool::HostAccessor_t);
+void deallocate_program(const Program &, PortableMemPool::HostAccessor_t);
 } // namespace FunGPU::EvaluatorV2

--- a/Core/EvaluatorV2/RuntimeBlock.hpp
+++ b/Core/EvaluatorV2/RuntimeBlock.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "Core/Concepts.h"
 #include "Core/EvaluatorV2/Instruction.h"
+#include "Core/EvaluatorV2/Program.hpp"
 #include "Core/EvaluatorV2/RuntimeValue.h"
 #include "Core/PortableMemPool.hpp"
 #include "Core/Types.hpp"
@@ -45,16 +47,29 @@ public:
     Index_t max_num_instructions = 0;
   };
 
-  enum class Status { READY, STALLED, COMPLETE, ALLOCATION_ERROR };
+  enum class Status { READY, STALLED, COMPLETE };
 
   using InstructionLocalMemAccessor =
       cl::sycl::accessor<Instruction, 2, cl::sycl::access::mode::read_write,
                          cl::sycl::access::target::local>;
+  using PreAllocatedRuntimeValuesPerThread = std::array<
+      PortableMemPool::ArrayHandle<PortableMemPool::ArrayHandle<RuntimeValue>>,
+      ThreadsPerBlock>;
+
+  template <cl::sycl::access::target ACCESS_TARGET>
+  static PreAllocatedRuntimeValuesPerThread pre_allocate_runtime_values(
+      Index_t num_threads,
+      cl::sycl::accessor<PortableMemPool, 1, cl::sycl::access::mode::read_write,
+                         ACCESS_TARGET>,
+      Program, Index_t lambda_idx);
 
   explicit RuntimeBlock(
       const PortableMemPool::ArrayHandle<Instruction> instructions,
+      const PreAllocatedRuntimeValuesPerThread pre_allocated_runtime_values,
       const Index_t num_threads)
-      : instruction_ref(instructions), num_threads(num_threads) {}
+      : instruction_ref(instructions),
+        pre_allocated_runtime_values(pre_allocated_runtime_values),
+        num_threads(num_threads) {}
 
   // RuntimeBlock must be loaded into local memory before invoking evaluate
   template <typename OnIndirectCall, typename OnActivateBlock>
@@ -78,6 +93,9 @@ public:
                        const RuntimeValue value,
                        OnActivateBlock &&on_activate_block);
 
+  void deallocate_runtime_values_array_for_thread(
+      PortableMemPool::DeviceAccessor_t mem_pool, Index_t thread);
+
   BlockMetadata block_metadata() const {
     return BlockMetadata(m_handle, instruction_ref, num_threads);
   }
@@ -86,11 +104,20 @@ public:
       registers;
   PortableMemPool::Handle<RuntimeBlock> m_handle;
   PortableMemPool::ArrayHandle<Instruction> instruction_ref;
+  PreAllocatedRuntimeValuesPerThread pre_allocated_runtime_values;
   TargetAddress target_data[ThreadsPerBlock];
   Index_t num_threads;
   Index_t cur_cycle = 0;
+  Index_t pre_allocated_runtime_values_idx = 0;
   int num_outstanding_dependencies = 0;
 };
+
+template <Index_t RegistersPerThread, Index_t ThreadsPerBlock>
+void RuntimeBlock<RegistersPerThread, ThreadsPerBlock>::
+    deallocate_runtime_values_array_for_thread(
+        PortableMemPool::DeviceAccessor_t mem_pool, const Index_t thread_idx) {
+  mem_pool[0].DeallocArray(pre_allocated_runtime_values[thread_idx]);
+}
 
 template <Index_t RegistersPerThread, Index_t ThreadsPerBlock>
 Index_t RuntimeBlock<RegistersPerThread, ThreadsPerBlock>::last_write_location(
@@ -142,6 +169,9 @@ auto RuntimeBlock<RegistersPerThread, ThreadsPerBlock>::evaluate(
     OnActivateBlock &&on_activate_block) -> Status {
   auto &register_set = registers[thread];
   const auto &instructions = all_instructions[block_idx];
+  auto &pre_allocated_rvs = pre_allocated_runtime_values[thread];
+  auto local_pre_allocated_runtime_values_idx =
+      pre_allocated_runtime_values_idx;
 #define HANDLE_BINARY_OP(TYPE, OP)                                             \
   [&](const TYPE &type) {                                                      \
     auto &target_register = register_set[type.target_register];                \
@@ -155,18 +185,27 @@ auto RuntimeBlock<RegistersPerThread, ThreadsPerBlock>::evaluate(
   const auto allocate_arg_values = [&](const auto &call_indirect) {
     const auto arg_indices_handle = call_indirect.arg_indices.unpack();
     const auto *arg_indices = mem_pool[0].derefHandle(arg_indices_handle);
-    auto arg_values =
-        mem_pool[0].AllocArray<RuntimeValue>(arg_indices_handle.GetCount());
-    if (arg_values == PortableMemPool::ArrayHandle<RuntimeValue>() &&
-        arg_indices_handle.GetCount() > 0) {
-      return arg_values;
-    }
+    auto *pre_allocated_runtime_values_data =
+        mem_pool[0].derefHandle(pre_allocated_rvs);
+    auto arg_values = pre_allocated_runtime_values_data
+        [local_pre_allocated_runtime_values_idx++];
     auto *arg_values_data = mem_pool[0].derefHandle(arg_values);
     for (Index_t i = 0; i < arg_indices_handle.GetCount(); ++i) {
       arg_values_data[i] = register_set[arg_indices[i]];
     }
     return arg_values;
   };
+
+  const auto deallocate_runtime_values = Visitor{
+      [&](const OneOf<CallIndirect, BlockingCallIndirect, CreateLambda> auto
+              &op_with_rvs) {
+        auto *pre_alloated_runtime_values_data =
+            mem_pool[0].derefHandle(pre_allocated_rvs);
+        mem_pool[0].DeallocArray(pre_alloated_runtime_values_data
+                                     [local_pre_allocated_runtime_values_idx]);
+        return true;
+      },
+      [](const auto &) { return false; }};
 
   const auto non_control_flow_handlers = Visitor{
       HANDLE_BINARY_OP(Add, +),
@@ -211,12 +250,9 @@ auto RuntimeBlock<RegistersPerThread, ThreadsPerBlock>::evaluate(
         auto *captured_indices =
             mem_pool[0].derefHandle(captured_indices_handle);
         auto &target_register = register_set[create_lambda.target_register];
-        auto captured_values = mem_pool[0].AllocArray<RuntimeValue>(
-            captured_indices_handle.GetCount());
-        if (captured_values == PortableMemPool::ArrayHandle<RuntimeValue>() &&
-            captured_indices_handle.GetCount() > 0) {
-          return Status::ALLOCATION_ERROR;
-        }
+        auto *rv_data = mem_pool[0].derefHandle(pre_allocated_rvs);
+        const auto captured_values =
+            rv_data[local_pre_allocated_runtime_values_idx++];
         auto *captured_values_data = mem_pool[0].derefHandle(captured_values);
         target_register.data.function_val =
             FunctionValue(create_lambda.block_idx, captured_values);
@@ -227,10 +263,6 @@ auto RuntimeBlock<RegistersPerThread, ThreadsPerBlock>::evaluate(
       },
       [&](const CallIndirect &call_indirect) {
         const auto arg_values = allocate_arg_values(call_indirect);
-        if (arg_values == PortableMemPool::ArrayHandle<RuntimeValue>() &&
-            call_indirect.arg_indices.unpack().GetCount() > 0) {
-          return Status::ALLOCATION_ERROR;
-        }
         cl::sycl::atomic_ref<int, cl::sycl::memory_order::seq_cst,
                              cl::sycl::memory_scope::work_group,
                              cl::sycl::access::address_space::local_space>
@@ -244,10 +276,6 @@ auto RuntimeBlock<RegistersPerThread, ThreadsPerBlock>::evaluate(
       },
       [&](const BlockingCallIndirect &blocking_call_indirect) {
         const auto arg_values = allocate_arg_values(blocking_call_indirect);
-        if (arg_values == PortableMemPool::ArrayHandle<RuntimeValue>() &&
-            blocking_call_indirect.arg_indices.unpack().GetCount() > 0) {
-          return Status::ALLOCATION_ERROR;
-        }
         const auto function_val =
             register_set[blocking_call_indirect.lambda_idx].data.function_val;
         const auto &target = target_data[thread];
@@ -291,10 +319,18 @@ auto RuntimeBlock<RegistersPerThread, ThreadsPerBlock>::evaluate(
         [&](const auto &instr) {
           if constexpr (std::is_same_v<If,
                                        std::remove_cvref_t<decltype(instr)>>) {
-            const auto &next_instr =
-                static_cast<bool>(register_set[instr.predicate].data.float_val)
-                    ? instructions[instr.goto_true]
-                    : instructions[instr.goto_false];
+            const auto is_branch_true =
+                static_cast<bool>(register_set[instr.predicate].data.float_val);
+            const auto &next_instr = is_branch_true
+                                         ? instructions[instr.goto_true]
+                                         : instructions[instr.goto_false];
+            if (is_branch_true) {
+              deallocate_runtime_values(instructions[instr.goto_false]);
+            } else {
+              if (deallocate_runtime_values(instructions[instr.goto_true])) {
+                ++local_pre_allocated_runtime_values_idx;
+              }
+            }
             return visit(
                 next_instr,
                 [&](const auto &derived_next_instr) {
@@ -316,11 +352,10 @@ auto RuntimeBlock<RegistersPerThread, ThreadsPerBlock>::evaluate(
     ++local_cycle;
   }
   cl::sycl::group_barrier(itm.get_group());
-  cl::sycl::atomic_ref<Index_t, cl::sycl::memory_order::seq_cst,
-                       cl::sycl::memory_scope::work_group,
-                       cl::sycl::access::address_space::local_space>
-      cur_cycle_atomic(cur_cycle);
-  cur_cycle_atomic.fetch_max(local_cycle);
+  if (thread == 0) {
+    cur_cycle = local_cycle;
+    pre_allocated_runtime_values_idx = local_pre_allocated_runtime_values_idx;
+  }
   return status;
 }
 
@@ -339,4 +374,40 @@ void RuntimeBlock<RegistersPerThread, ThreadsPerBlock>::fill_dependency(
     on_activate_block(m_handle);
   }
 }
+
+template <Index_t RegistersPerThread, Index_t ThreadsPerBlock>
+template <cl::sycl::access::target ACCESS_TARGET>
+auto RuntimeBlock<RegistersPerThread, ThreadsPerBlock>::
+    pre_allocate_runtime_values(
+        const Index_t num_threads,
+        cl::sycl::accessor<PortableMemPool, 1,
+                           cl::sycl::access::mode::read_write, ACCESS_TARGET>
+            mem_pool_acc,
+        const Program program,
+        const Index_t lambda_idx) -> PreAllocatedRuntimeValuesPerThread {
+  const auto &instructions_data =
+      mem_pool_acc[0].derefHandle(program)[lambda_idx];
+
+  PreAllocatedRuntimeValuesPerThread pre_allocated_rvs;
+
+  for (Index_t thread_idx = 0; thread_idx < num_threads; ++thread_idx) {
+    pre_allocated_rvs[thread_idx] =
+        mem_pool_acc[0]
+            .template AllocArray<PortableMemPool::ArrayHandle<RuntimeValue>>(
+                instructions_data.instruction_properties
+                    .num_runtime_values_per_op.GetCount());
+    const auto *num_rvs_per_op = mem_pool_acc[0].derefHandle(
+        instructions_data.instruction_properties.num_runtime_values_per_op);
+    auto *pre_allocated_rv_data =
+        mem_pool_acc[0].derefHandle(pre_allocated_rvs[thread_idx]);
+    for (Index_t op_idx = 0; op_idx < pre_allocated_rvs[thread_idx].GetCount();
+         ++op_idx) {
+      pre_allocated_rv_data[op_idx] =
+          mem_pool_acc[0].template AllocArray<RuntimeValue>(
+              num_rvs_per_op[op_idx]);
+    }
+  }
+  return pre_allocated_rvs;
+}
+
 } // namespace FunGPU::EvaluatorV2

--- a/Core/EvaluatorV2/tests/RuntimeBlock.cpp
+++ b/Core/EvaluatorV2/tests/RuntimeBlock.cpp
@@ -107,8 +107,11 @@ struct Fixture {
       auto mem_pool_acc =
           mem_pool_buffer.get_access<cl::sycl::access::mode::read_write>();
       const auto *lambdas = mem_pool_acc[0].derefHandle(no_bindings_program);
+      const auto pre_allocated_rvs =
+          RuntimeBlockType::pre_allocate_runtime_values(
+              THREADS_PER_BLOCK, mem_pool_acc, no_bindings_program, 0);
       const auto block_handle = mem_pool_acc[0].Alloc<RuntimeBlockType>(
-          lambdas[0].instructions, THREADS_PER_BLOCK);
+          lambdas[0].instructions, pre_allocated_rvs, THREADS_PER_BLOCK);
       const auto block_metadata_array =
           mem_pool_acc[0].AllocArray<RuntimeBlockType::BlockMetadata>(1);
       auto *block_meta_array_data =
@@ -139,8 +142,12 @@ struct Fixture {
         const auto no_bindings_program = generate_program(prog);
         BOOST_REQUIRE_EQUAL(1, no_bindings_program.GetCount());
         const auto *lambdas = mem_pool_acc[0].derefHandle(no_bindings_program);
+        const auto pre_allocate_runtime_values =
+            RuntimeBlockType::pre_allocate_runtime_values(
+                THREADS_PER_BLOCK, mem_pool_acc, no_bindings_program, 0);
         const auto block_handle = mem_pool_acc[0].Alloc<RuntimeBlockType>(
-            lambdas[0].instructions, THREADS_PER_BLOCK);
+            lambdas[0].instructions, pre_allocate_runtime_values,
+            THREADS_PER_BLOCK);
         BOOST_REQUIRE(block_handle !=
                       PortableMemPool::Handle<RuntimeBlockType>());
         block_metadata_array_data[i++] = RuntimeBlockType::BlockMetadata(


### PR DESCRIPTION
Scope all dynamic allocations to the block scheduling phase. Determine the number of runtime values required for each instruction per block during block generation. Preallocate all runtime values that may be needed during block setup.

This modification is a step towards eliminating all failures in the RuntimeBlock::evaluate step that may occur due to insufficient resources. The scheduling phase should ensure that sufficient resources are present to evaluate the next set of generated blocks, moving all pending blocks to host memory until resources are available.