### PR TITLE
Evaluator: fix bug impacting branch in tail position

### DIFF
--- a/Core/BlockPrep.cpp
+++ b/Core/BlockPrep.cpp
@@ -1,7 +1,5 @@
 #include "Core/BlockPrep.hpp"
-#include "Compiler.hpp"
 #include "Core/CollectAllASTNodes.hpp"
-#include "Core/Compiler.hpp"
 #include "Core/Visitor.hpp"
 
 namespace FunGPU {

--- a/Core/EvaluatorV2/Instruction.h
+++ b/Core/EvaluatorV2/Instruction.h
@@ -177,7 +177,7 @@ decltype(auto) visit(const Instruction &instruction, CB &&cb,
     _(InstructionBarrier)
   }
 
-  unexpected_cb(instruction);
+  return unexpected_cb(instruction);
 #undef _
 }
 
@@ -187,10 +187,11 @@ decltype(auto) visit(Instruction &instruction, CB &&cb,
   return visit(
       std::as_const(instruction),
       [&](const auto &elem) {
-        cb(const_cast<std::remove_cvref_t<decltype(elem)> &>(elem));
+        return cb(const_cast<std::remove_cvref_t<decltype(elem)> &>(elem));
       },
       [&](const auto &elem) {
-        unexpected_cb(const_cast<std::remove_cvref_t<decltype(elem)> &>(elem));
+        return unexpected_cb(
+            const_cast<std::remove_cvref_t<decltype(elem)> &>(elem));
       });
 }
 } // namespace FunGPU::EvaluatorV2

--- a/Core/EvaluatorV2/tests/Evaluator.cpp
+++ b/Core/EvaluatorV2/tests/Evaluator.cpp
@@ -37,7 +37,7 @@ struct Fixture {
                   return create_lambda.captured_indices.unpack().GetCount() > 0;
                 },
                 [](const auto &) { return false; }},
-            [](const auto &) {
+            [](const auto &) -> bool {
               throw std::invalid_argument("Encountered unknown instruction");
             });
         if (contains_captures) {
@@ -119,6 +119,9 @@ BOOST_FIXTURE_TEST_CASE(BranchInBinding, Fixture) {
 }
 BOOST_FIXTURE_TEST_CASE(ConditionalLetRec, Fixture) {
   check_program_yields_result(120, "./TestPrograms/ConditionalLetRec.fgpu");
+}
+BOOST_FIXTURE_TEST_CASE(ExplicitFactorial, Fixture) {
+  check_program_yields_result(120, "./TestPrograms/ExplicitFactorial.fgpu");
 }
 } // namespace
 } // namespace FunGPU::EvaluatorV2

--- a/Core/EvaluatorV2/tests/RuntimeBlock.cpp
+++ b/Core/EvaluatorV2/tests/RuntimeBlock.cpp
@@ -74,8 +74,8 @@ struct Fixture {
             itm.barrier(cl::sycl::access::fence_space::local_space);
             RuntimeBlockType::Status status = local_block[0].evaluate(
                 block_idx, thread_idx, itm, mem_pool_write, local_instructions,
-                block_meta.instructions.GetCount(), [](auto &&...) {},
-                [](const auto) {});
+                block_meta.instructions.GetCount(), block_meta.num_threads,
+                [](auto &&...) {}, [](const auto) {});
             if (status == RuntimeBlockType::Status::COMPLETE) {
               results_acc[cl::sycl::id<2>(block_idx, thread_idx)] =
                   local_block[0].result(block_idx, thread_idx,

--- a/TestPrograms/ExplicitFactorial.fgpu
+++ b/TestPrograms/ExplicitFactorial.fgpu
@@ -1,0 +1,3 @@
+(let ((fact_0 (lambda (self x) (let ((get-one (lambda () 1)) (false-cont (lambda (func v) (* v (func func (- v 1))))))
+                                   (if (= x 0) (get-one) (false-cont self x))))))
+      (fact_0 fact_0 5))


### PR DESCRIPTION
The prior version did not advance the index for the preallocated runtime values array or deallocate the array for the branch not taken. Fix this issue and add a test program covering the case. Also fix undefined behavior where barriers were present in code that was not guaranteed to execute for all threads in a work group.