### PR TITLE
Evaluator: fix multiple compute calls

### DIFF
--- a/core/evaluator_v2/evaluator.hpp
+++ b/core/evaluator_v2/evaluator.hpp
@@ -25,13 +25,14 @@ private:
   PortableMemPool::Handle<RuntimeBlockType> construct_initial_block(Program);
   RuntimeValue read_result(PortableMemPool::Handle<RuntimeBlockType>);
 
-  void run_eval_step(RuntimeBlockType::BlockExecGroup);
-  std::optional<RuntimeBlockType::BlockExecGroup> schedule_next_batch(Program);
+  void run_eval_step(RuntimeBlockType::BlockExecGroup,
+                     IndirectCallHandlerType::Buffers &);
+  std::optional<RuntimeBlockType::BlockExecGroup>
+  schedule_next_batch(Program, IndirectCallHandlerType::Buffers &);
   void cleanup(RuntimeBlockType::BlockExecGroup);
 
   cl::sycl::buffer<PortableMemPool> mem_pool_buffer_;
   cl::sycl::buffer<bool> is_initial_block_ready_again_{cl::sycl::range<1>(1)};
-  IndirectCallHandlerType::Buffers indirect_call_handler_buffers_;
   std::shared_ptr<IndirectCallHandlerType> indirect_call_handler_data_ =
       std::make_shared<IndirectCallHandlerType>();
   cl::sycl::buffer<IndirectCallHandlerType> indirect_call_handler_buffer_{

--- a/core/evaluator_v2/indirect_call_handler.hpp
+++ b/core/evaluator_v2/indirect_call_handler.hpp
@@ -47,17 +47,12 @@ public:
           max_num_threads_per_lambda(cl::sycl::range<1>(1)),
           total_num_blocks(cl::sycl::range<1>(1)),
           result(cl::sycl::range<1>(1)), copy_begin_idx(cl::sycl::range<1>(1)),
-          indirect_call_requests_by_block(cl::sycl::range<1>(program_count)) {}
-
-    void update_for_num_lambdas(const std::size_t program_count) {
-      indirect_call_requests_by_block_data =
-          std::shared_ptr<IndirectCallRequestBuffer[]>(
-              new IndirectCallRequestBuffer[program_count]);
-      indirect_call_requests_by_block =
-          cl::sycl::buffer<IndirectCallRequestBuffer>(
+          indirect_call_requests_by_block_data(
+              std::shared_ptr<IndirectCallRequestBuffer[]>(
+                  new IndirectCallRequestBuffer[program_count])),
+          indirect_call_requests_by_block(
               indirect_call_requests_by_block_data.get(),
-              cl::sycl::range<1>(program_count));
-    }
+              cl::sycl::range<1>(program_count)) {}
 
     using IndirectCallAccessorType =
         cl::sycl::accessor<IndirectCallRequestBuffer, 1,

--- a/core/evaluator_v2/tests/evaluator.cpp
+++ b/core/evaluator_v2/tests/evaluator.cpp
@@ -106,7 +106,7 @@ struct Fixture {
     fgpu_program_file << fgpu_program;
     fgpu_program_file.close();
     compiler.deallocate_ast(compiled_result);
-    // check_program_yields_result(expected_val, program_path);
+    check_program_yields_result(expected_val, program_path);
     check_program_yields_result(expected_val, updated_program_path);
   }
 };

--- a/core/evaluator_v2/tests/indirect_call_handler.cpp
+++ b/core/evaluator_v2/tests/indirect_call_handler.cpp
@@ -22,7 +22,6 @@ struct Fixture {
         << "Running on "
         << work_queue.get_device().get_info<cl::sycl::info::device::name>()
         << ", block size: " << sizeof(RuntimeBlockType) << std::endl;
-    buffers.update_for_num_lambdas(program.get_count());
   }
 
   std::shared_ptr<PortableMemPool> mem_pool_data =


### PR DESCRIPTION
Reallocating the IndirectCallHandler::Buffers struct causes a segfault when copying data to the device with the CUDA backend. Allocate a new buffer set for each `compute` invocation.