### PR TITLE
Evaluator: remove constant max block count

### DIFF
--- a/core/evaluator_v2/evaluator.hpp
+++ b/core/evaluator_v2/evaluator.hpp
@@ -30,6 +30,7 @@ private:
   std::optional<RuntimeBlockType::BlockExecGroup>
   schedule_next_batch(Program, IndirectCallHandlerType::Buffers &);
   void cleanup(RuntimeBlockType::BlockExecGroup);
+  void check_program_does_not_overflow_shared_memory(const Program &);
 
   cl::sycl::buffer<PortableMemPool> mem_pool_buffer_;
   cl::sycl::buffer<bool> is_initial_block_ready_again_{cl::sycl::range<1>(1)};
@@ -39,5 +40,6 @@ private:
       indirect_call_handler_data_, cl::sycl::range<1>(1)};
   PortableMemPool::Handle<RuntimeBlockType> first_block_;
   cl::sycl::queue work_queue_;
+  const size_t num_shared_memory_bytes_;
 };
 } // namespace FunGPU::EvaluatorV2

--- a/core/evaluator_v2/instruction.hpp
+++ b/core/evaluator_v2/instruction.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "core/evaluator_v2/runtime_value.hpp"
 #include "core/portable_mem_pool.hpp"
 #include "core/types.hpp"
+#include <cstdint>
 #include <string>
 #include <type_traits>
 
 namespace FunGPU::EvaluatorV2 {
-enum class InstructionType {
+enum class InstructionType : std::uint8_t {
   CREATE_LAMBDA,
   ASSIGN_CONSTANT,
   ASSIGN,

--- a/core/evaluator_v2/program.cpp
+++ b/core/evaluator_v2/program.cpp
@@ -1,6 +1,6 @@
 #include "core/evaluator_v2/program.hpp"
+#include <span>
 #include <sstream>
-
 namespace FunGPU::EvaluatorV2 {
 std::string print(const Program &program,
                   PortableMemPool::HostAccessor_t mem_pool_acc) {
@@ -21,5 +21,17 @@ void deallocate_program(const Program &program,
     lambda.deallocate(mem_pool_acc);
   }
   mem_pool_acc[0].dealloc_array(program);
+}
+
+Index_t max_num_instructions_in_program(
+    const Program &program,
+    PortableMemPool::HostReadOnlyAccessorType mem_pool_acc) {
+  Index_t max_num_instructions = 0;
+  for (const auto &lambda :
+       std::span(mem_pool_acc[0].deref_handle(program), program.get_count())) {
+    max_num_instructions =
+        std::max(max_num_instructions, lambda.instructions.get_count());
+  }
+  return max_num_instructions;
 }
 } // namespace FunGPU::EvaluatorV2

--- a/core/evaluator_v2/program.hpp
+++ b/core/evaluator_v2/program.hpp
@@ -8,4 +8,7 @@ using Program = PortableMemPool::ArrayHandle<Lambda>;
 
 std::string print(const Program &, PortableMemPool::HostAccessor_t);
 void deallocate_program(const Program &, PortableMemPool::HostAccessor_t);
+Index_t
+max_num_instructions_in_program(const Program &,
+                                PortableMemPool::HostReadOnlyAccessorType);
 } // namespace FunGPU::EvaluatorV2

--- a/core/portable_mem_pool.hpp
+++ b/core/portable_mem_pool.hpp
@@ -23,6 +23,10 @@ public:
   using HostAccessor_t =
       cl::sycl::accessor<PortableMemPool, 1, cl::sycl::access::mode::read_write,
                          cl::sycl::access::target::host_buffer>;
+  using HostReadOnlyAccessorType =
+      cl::sycl::accessor<PortableMemPool, 1, cl::sycl::access::mode::read,
+                         cl::sycl::access::target::host_buffer>;
+
   template <class T> class Handle {
   public:
     Handle() : m_distFromMemPoolBase(std::numeric_limits<Index_t>::max()) {}
@@ -168,6 +172,18 @@ public:
   template <class T> void dealloc_array(const ArrayHandle<T> &arrayHandle) {
     DeallocArrayImpl(arrayHandle, m_smallBin, m_mediumBin, m_largeBin,
                      m_extraLargeBin);
+  }
+
+  template <class T>
+  std::add_const_t<T> *deref_handle(const Handle<T> &handle) const {
+    return reinterpret_cast<std::add_const_t<T> *>(
+        reinterpret_cast<const std::byte *>(this) +
+        handle.get_dist_from_mem_pool_base());
+  }
+
+  template <class T>
+  const std::add_const_t<T> *deref_handle(const ArrayHandle<T> &handle) const {
+    return deref_handle(handle.m_handle);
   }
 
   template <class T> T *deref_handle(const Handle<T> &handle) {


### PR DESCRIPTION
The shared memory size is specified per work group on all SYCL backends. The shared memory requirement is a function of the program (max num instructions across lambdas) and the size of RuntimeBlock. Assert that the input program does not require more shared memory than is available per block on the target device and remove the max block count per launch constraint. The SYCL backend will handle fragmenting a large number of blocks across SMs based on the required shared memory.